### PR TITLE
Update acisfp_check to work with updated version of acis_thermal_check

### DIFF
--- a/acisfp_check/__init__.py
+++ b/acisfp_check/__init__.py
@@ -1,1 +1,7 @@
-__version__ = "2.1.0"
+__version__ = "2.2.0"
+
+from .acisfp_check import \
+    ACISFPCheck, calc_model
+
+from .acis_obs import \
+    ObsidFindFilter

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -149,22 +149,6 @@ class ACISFPCheck(ACISThermalCheck):
                                           other_telem=other_telem, other_map=other_map)
         self.fp_sens_limit, self.acis_i_limit, self.acis_s_limit = get_acis_limits("fptemp")
 
-    def calc_model_wrapper(self, model_spec, states, tstart, tstop, state0=None):
-        if state0 is None:
-            start_msid = None
-            dh_heater = None
-            dh_heater_times = None
-        else:
-            start_msid = state0[self.msid]
-            htrbfn = os.path.join(self.bsdir, 'dahtbon_history.rdb')
-            mylog.info('Reading file of dahtrb commands from file %s' % htrbfn)
-            htrb = ascii.read(htrbfn, format='rdb')
-            dh_heater_times = date2secs(htrb['time'])
-            dh_heater = htrb['dahtbon'].astype(bool)
-        return self.calc_model(model_spec, states, tstart, tstop, T_acisfp=start_msid,
-                               T_acisfp_times=None, dh_heater=dh_heater, 
-                               dh_heater_times=dh_heater_times)
-
     def make_week_predict(self, tstart, tstop, tlm, T_init, model_spec,
                           outdir):
 

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -31,7 +31,7 @@ from acis_thermal_check import \
     get_options, \
     mylog, get_acis_limits
 from acis_thermal_check.utils import \
-    plot_two, plot_one
+    plot_two
 import os
 import sys
 from kadi import events

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -16,7 +16,6 @@ from __future__ import print_function
 # Use Agg backend for command-line (non-interactive) operation
 import matplotlib
 matplotlib.use('Agg')
-import matplotlib.pyplot as plt
 
 import glob
 from Ska.Matplotlib import pointpair, \

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -160,6 +160,14 @@ def calc_model(model_spec, states, start, stop, T_acisfp=None,
 
 class ACISFPCheck(ACISThermalCheck):
 
+    def __init__(self, msid, name, MSIDs, validation_limits,
+                 hist_limit, calc_model, args, other_telem=None,
+                 other_map=None):
+        super(ACISFPCheck, self).__init__(msid, name, MSIDs, validation_limits,
+                                          hist_limit, calc_model, args, 
+                                          other_telem=other_telem, other_map=other_map)
+        self.fp_sens_limit, self.acis_i_limit, self.acis_s_limit = get_acis_limits("fptemp")
+
     def calc_model_wrapper(self, model_spec, states, tstart, tstop, state0=None):
         if state0 is None:
             start_msid = None

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -344,43 +344,8 @@ class ACISFPCheck(ACISThermalCheck):
             plots[name]['fig'].savefig(outfile)
             plots[name]['filename'] = filename
 
-        # Now create the plot of ACIS CCD number and Sim-Z position
-        plots['pow_sim'] = plot_two(
-            fig_id=4,
-            title='ACIS CCDs and SIM-Z position',
-            xlabel='Date',
-            x=pointpair(states['tstart'], states['tstop']),
-            y=pointpair(states['ccd_count']),
-            ylabel='CCD_COUNT',
-            ylim=(-0.1, 6.1),
-            x2=pointpair(states['tstart'], states['tstop']),
-            y2=pointpair(states['simpos']),
-            ylabel2='SIM-Z (steps)',
-            xmin=plot_start,
-            ylim2=(-105000, 105000),
-            figsize=(12, 6), width=w1, load_start=load_start)
-        filename = 'pow_sim.png'
-        outfile = os.path.join(outdir, filename)
-        mylog.info('   Writing plot file %s' % outfile)
-        plots['pow_sim']['fig'].savefig(outfile)
-        plots['pow_sim']['filename'] = filename
-
-        # Make a plot of off-nominal roll
-        plots['roll'] = plot_one(
-            fig_id=5,
-            title='Off-Nominal Roll',
-            xlabel='Date',
-            x=pointpair(states['tstart'], states['tstop']),
-            y=pointpair(calc_off_nom_rolls(states)),
-            ylabel='Roll Angle (deg)',
-            ylim=(-20.0, 20.0),
-            xmin=plot_start,
-            figsize=(12, 6), width=w1, load_start=load_start)
-        filename = 'roll.png'
-        outfile = os.path.join(outdir, filename)
-        mylog.info('Writing plot file %s' % outfile)
-        plots['roll']['fig'].savefig(outfile)
-        plots['roll']['filename'] = filename
+        self._make_state_plots(plots, 3, w1, plot_start,
+                               outdir, states, load_start)
 
         return plots
 

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -32,8 +32,7 @@ from acis_thermal_check import \
     ACISThermalCheck, \
     calc_off_nom_rolls, \
     get_options, \
-    make_state_builder, \
-    mylog
+    mylog, get_acis_limits
 from acis_thermal_check.utils import \
     plot_two, plot_one
 import os
@@ -1060,14 +1059,13 @@ def main():
     opts = [("fps_nopref", {"default": default_nopref_list,
              "help": "Full path to the FP sensitive nopref file"})]
     args = get_options("acisfp", model_path, opts=opts)
-    state_builder = make_state_builder(args.state_builder, args)
-    acisfp_check = ACISFPCheck("fptemp", "acisfp", MSID, YELLOW,
-                               MARGIN, VALIDATION_LIMITS, HIST_LIMIT, 
-                               calc_model, other_telem=['1dahtbon'],
-                               other_map={'1dahtbon': 'dh_heater', 
+    acisfp_check = ACISFPCheck("fptemp", "acisfp", MSID, VALIDATION_LIMITS, 
+                               HIST_LIMIT, calc_model, args,
+                               other_telem=['1dahtbon'],
+                               other_map={'1dahtbon': 'dh_heater',
                                           "fptemp_11": "fptemp"})
     try:
-        acisfp_check.driver(args, state_builder)
+        acisfp_check.driver()
     except Exception as msg:
         if args.traceback:
             raise

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -941,7 +941,7 @@ def main():
                                other_map={'1dahtbon': 'dh_heater',
                                           "fptemp_11": "fptemp"})
     try:
-        acisfp_check.driver()
+        acisfp_check.run()
     except Exception as msg:
         if args.traceback:
             raise

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -299,7 +299,7 @@ class ACISFPCheck(ACISThermalCheck):
         w1 = None
         # Make plots of FPTEMP and pitch vs time, looping over
         # three different temperature ranges
-        ylim = [(-120, -90), (-120, 119), (-120.0, -111.5)]
+        ylim = [(-120, -90), (-120, -119), (-120.0, -111.5)]
         ypos = [-110.0, -119.35, -116]
         capwidth = [2.0, 0.1, 0.4]
         textypos = [-108.0, -119.3, -115.7]
@@ -337,14 +337,14 @@ class ACISFPCheck(ACISThermalCheck):
                         textypos[i], fontsize[i], plot_start)
 
             # Build the file name and output the plot to a file
-            filename = self.msid.lower() + 'M%dto%d.png' % (-ylim[i][0], -ylim[i][1])
+            filename = self.msid.lower() + 'M%dtoM%d.png' % (-ylim[i][0], -ylim[i][1])
             outfile = os.path.join(outdir, filename)
             mylog.info('Writing plot file %s' % outfile)
             plots[name]['fig'].savefig(outfile)
             plots[name]['filename'] = filename
 
         self._make_state_plots(plots, 3, w1, plot_start,
-                               outdir, states, load_start)
+                               outdir, states, load_start, figsize=(12, 6))
 
         return plots
 

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -60,7 +60,6 @@ MARGIN = {"acisfp": 2.5}
 # if the FP temp goes above this number, and the obswervation is sensitive to
 # the focal plane temperature, it has to be flagged
 FP_TEMP_SENSITIVE = {"acisfp": -118.7}
-FP_TEMP_MINIMUM = {"acisfp": -118.7}
 
 # This is the new maximum temperature for all ACIS-S observations (4/26/16)
 ACIS_S_RED = {"acisfp": -112.0}

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -53,8 +53,10 @@ default_nopref_list = os.path.join(model_path, "FPS_NoPref.txt")
 # INIT
 #
 MSID = {"acisfp": "FPTEMP"}
-YELLOW = {"acisfp": -50.0}
-MARGIN = {"acisfp": 2.5}
+# The next two limits don't apply to this model
+# so we set them to None
+YELLOW = None
+MARGIN = None
 
 # This is the cutoff temperature for any FPTEMP sensitive observation
 # if the FP temp goes above this number, and the obswervation is sensitive to

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -337,7 +337,7 @@ class ACISFPCheck(ACISThermalCheck):
                         textypos[i], fontsize[i], plot_start)
 
             # Build the file name and output the plot to a file
-            filename = MSID[self.name].lower() + 'M%dto%d.png' % (-ylim[i][0], -ylim[i][1])
+            filename = self.msid.lower() + 'M%dto%d.png' % (-ylim[i][0], -ylim[i][1])
             outfile = os.path.join(outdir, filename)
             mylog.info('Writing plot file %s' % outfile)
             plots[name]['fig'].savefig(outfile)
@@ -423,7 +423,7 @@ class ACISFPCheck(ACISThermalCheck):
         # Collect any -118.7C violations of CTI runs. These are not
         # load killers but need to be reported
 
-        viols["cti"] = search_obsids_for_viols(self.msid, self.name, self.fp_sens_limit,
+        viols["cti"] = search_obsids_for_viols(self.msid, self.fp_sens_limit,
                                                cti_only_obs, temp, times, load_start)
 
         # ------------------------------------------------------------
@@ -432,7 +432,7 @@ class ACISFPCheck(ACISThermalCheck):
         # ------------------------------------------------------------
         mylog.info('\n\nFP SENSITIVE -118.7 SCIENCE ONLY violations')
 
-        viols["fp_sens"] = search_obsids_for_viols(self.msid, self.name, self.fp_sens_limit,
+        viols["fp_sens"] = search_obsids_for_viols(self.msid, self.fp_sens_limit,
                                                    fp_sense_without_noprefs, temp, times,
                                                    load_start)
 
@@ -443,7 +443,7 @@ class ACISFPCheck(ACISThermalCheck):
         #
         mylog.info('\n\n ACIS-S -112 SCIENCE ONLY violations')
 
-        viols["ACIS_S"] = search_obsids_for_viols(self.msid, self.name, self.acis_s_limit,
+        viols["ACIS_S"] = search_obsids_for_viols(self.msid, self.acis_s_limit,
                                                   ACIS_S_obs, temp, times, load_start)
 
         # --------------------------------------------------------------
@@ -454,7 +454,7 @@ class ACISFPCheck(ACISThermalCheck):
         mylog.info('\n\n ACIS-I -114 SCIENCE ONLY violations')
 
         # Create the violation data structure.
-        viols["ACIS_I"] = search_obsids_for_viols(self.msid, self.name, self.acis_i_limit,
+        viols["ACIS_I"] = search_obsids_for_viols(self.msid, self.acis_i_limit,
                                                   ACIS_I_obs, temp, times, load_start)
 
         return viols
@@ -480,7 +480,7 @@ class ACISFPCheck(ACISThermalCheck):
         """
         return (tlm[self.msid] >= limit[0]) & (tlm[self.msid] <= limit[1])
 
-def search_obsids_for_viols(msid, name, plan_limit, observations, temp, times,
+def search_obsids_for_viols(msid, plan_limit, observations, temp, times,
                             load_start):
     """
     Given a planning limit and a list of observations, find those time intervals
@@ -552,7 +552,7 @@ def search_obsids_for_viols(msid, name, plan_limit, observations, temp, times,
 
             mylog.info('   VIOLATION: %s  exceeds planning limit of %.2f '
                         'degC from %s to %s'
-                        % (MSID[name], plan_limit, viol['datestart'],
+                        % (msid, plan_limit, viol['datestart'],
                         viol['datestop']))
 
     # Finished - return the violations list

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -48,7 +48,6 @@ default_nopref_list = os.path.join(model_path, "FPS_NoPref.txt")
 #
 # INIT
 #
-MSID = {"acisfp": "FPTEMP"}
 VALIDATION_LIMITS = {'PITCH': [(1, 3.0), (99, 3.0)],
                      'TSCPOS': [(1, 2.5), (99, 2.5)]
                      }
@@ -135,10 +134,10 @@ def calc_model(model_spec, states, start, stop, T_acisfp=None,
 
 class ACISFPCheck(ACISThermalCheck):
 
-    def __init__(self, msid, name, MSIDs, validation_limits,
+    def __init__(self, msid, name, validation_limits,
                  hist_limit, calc_model, args, other_telem=None,
                  other_map=None):
-        super(ACISFPCheck, self).__init__(msid, name, MSIDs, validation_limits,
+        super(ACISFPCheck, self).__init__(msid, name, validation_limits,
                                           hist_limit, calc_model, args, 
                                           other_telem=other_telem, other_map=other_map)
         # Set specific limits for the focal plane model
@@ -310,7 +309,7 @@ class ACISFPCheck(ACISThermalCheck):
             plots[name] = plot_two(fig_id=i+1, x=times, y=temps[self.name],
                                    x2=pointpair(states['tstart'], states['tstop']),
                                    y2=pointpair(states['pitch']),
-                                   title=MSID[self.name] + " (ACIS-I obs. in red; ACIS-S in green)",
+                                   title=self.msid.upper() + " (ACIS-I obs. in red; ACIS-S in green)",
                                    xlabel='Date', ylabel='Temperature (C)',
                                    ylabel2='Pitch (deg)', xmin=plot_start,
                                    ylim=ylim[i], ylim2=(40, 180),
@@ -749,7 +748,7 @@ def main():
     opts = [("fps_nopref", {"default": default_nopref_list,
              "help": "Full path to the FP sensitive nopref file"})]
     args = get_options("acisfp", model_path, opts=opts)
-    acisfp_check = ACISFPCheck("fptemp", "acisfp", MSID, VALIDATION_LIMITS, 
+    acisfp_check = ACISFPCheck("fptemp", "acisfp", VALIDATION_LIMITS, 
                                HIST_LIMIT, calc_model, args,
                                other_telem=['1dahtbon'],
                                other_map={'1dahtbon': 'dh_heater',

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -24,7 +24,6 @@ from Ska.Matplotlib import pointpair, \
     cxctime2plotdate
 import Ska.engarchive.fetch_sci as fetch
 from Chandra.Time import DateTime, date2secs
-from astropy.io import ascii
 from collections import defaultdict
 import numpy as np
 import xija

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -19,7 +19,6 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
 import glob
-import re
 from Ska.Matplotlib import pointpair, \
     cxctime2plotdate
 import Ska.engarchive.fetch_sci as fetch
@@ -147,10 +146,25 @@ class ACISFPCheck(ACISThermalCheck):
         self.fp_sens_limit, self.acis_i_limit, self.acis_s_limit = get_acis_limits("fptemp")
         # Read in the FP Sensitive Nopref file and form nopref array from it.
         self.nopref_array = process_nopref_list(self.args.fps_nopref)
+        # Create an empty observation list which will hold the results. This
+        # list contains all ACIS and all CTI observations and will have the 
+        # sensitivity boolean added.
+        self.obs_with_sensitivity = []
 
-    def _gather_perigee(self, tstart, state0):
+    def _gather_perigee(self, run_start, load_start):
         # The first step is to build a list of all the perigee passages.
-        # We will get those from the relevant CRM pad time file
+        perigee_passages = []
+
+        # Gather the perigee passages that occur from the
+        # beginning of the model run up to the start of the load
+        # from kadi
+        rzs = events.rad_zones.filter(run_start, load_start)
+        for rz in rzs:
+            perigee_passages.append([rz.start, rz.perigee])
+        for rz in rzs:
+            perigee_passages.append([rz.stop, rz.perigee])
+
+        # We will get the load passages from the relevant CRM pad time file
         # (e.g. DO12143_CRM_Pad.txt) inside the bsdir directory
         # Each line is either an inbound  or outbound CTI
         #
@@ -174,9 +188,6 @@ class ACISFPCheck(ACISThermalCheck):
             raise RuntimeError("Couldn't find the end of the CRM Pad Time file header!")
 
         # Found the last line of the header. Start processing Perigee Passages
-        # initialize the resultant Perigee Passage list to empty
-        # This is the product of this section of code.
-        perigee_passages = []
 
         # While there are still lines to be read
         for aline in alines[idx:]:
@@ -195,76 +206,9 @@ class ACISFPCheck(ACISThermalCheck):
         # Done with the CRM Pad Time file - close it
         crm_file.close()
 
-        # Now we gather the perigee passages that occur from the
-        # beginning of the model run up to the start of the load
-        # from kadi
-        rzs = events.rad_zones.filter(state0['tstart'], tstart)
-        perigee_passages = [[rz.start, rz.perigee] for rz in rzs] + \
-                           [[rz.stop, rz.perigee] for rz in rzs] + \
-                           perigee_passages
-
         return perigee_passages
 
-    def make_week_predict(self, tstart, tstop, tlm, T_init, model_spec,
-                          outdir):
-        """
-        Parameters
-        ----------
-        tstart : float
-            The start time of the model run in seconds from the beginning
-            of the mission.
-        tstop : float
-            The stop time of the model run in seconds from the beginning
-            of the mission.
-        tlm : NumPy structured array
-            Telemetry which will be used to construct the initial temperature
-        T_init : float
-            The initial temperature of the model prediction. If None, an
-            initial value will be constructed from telemetry.
-        model_spec : string
-            The path to the thermal model specification.
-        outdir : string
-            The directory to write outputs to.
-        """
-        mylog.info('Calculating %s thermal model' % self.name.upper())
-
-        # Get commanded states and set initial temperature
-        states, state0 = self.get_states(tlm, T_init)
-
-        # Determine perigee passages
-        perigee_passages = self._gather_perigee(tstart, state0)
-
-        # calc_model_wrapper actually does the model calculation by running
-        # model-specific code.
-        model = self.calc_model_wrapper(model_spec, states, state0['tstart'],
-                                        tstop, state0=state0)
-
-        # Make the limit check plots and data files
-        plt.rc("axes", labelsize=10, titlesize=12)
-        plt.rc("xtick", labelsize=10)
-        plt.rc("ytick", labelsize=10)
-        temps = {self.name: model.comp[self.msid].mvals}
-
-        # obs_with_sensitivity contains all ACIS and all CTI observations 
-        # and has had the sensitivity boolean added.
-        plots, obs_with_sensitivity = self.make_prediction_plots(outdir, states, 
-                                                                 model.times, temps, 
-                                                                 tstart, perigee_passages)
-
-        viols = self.make_prediction_viols(states, model.times, temps, tstart, 
-                                           obs_with_sensitivity)
-
-        # write_states writes the commanded states to states.dat
-        self.write_states(outdir, states)
-        # write_temps writes the temperatures to temperatures.dat
-        self.write_temps(outdir, model.times, temps)
-
-        return dict(states=states, times=model.times, temps=temps,
-                    plots=plots, ACIS_I_viols=viols[0], ACIS_S_viols=viols[1],
-                    cti_viols=viols[2], fp_sens_viols=viols[3])
-
-    def make_prediction_plots(self, outdir, states, times, temps, tstart, 
-                              perigee_passages):
+    def make_prediction_plots(self, outdir, states, times, temps, tstart):
         """
         Make output plots.
 
@@ -279,6 +223,9 @@ class ACISFPCheck(ACISThermalCheck):
         is populated with
         """
     
+        # Gather perigee passages
+        perigee_passages = self._gather_perigee(times[0], tstart)
+
         # Next we need to find all the ACIS-S observations within the start/stop
         # times so that we can paint those on the plots as well. We will get
         # those from the commanded states data structure called "states" 
@@ -326,11 +273,6 @@ class ACISFPCheck(ACISThermalCheck):
         # Now that you have the latest list of temperature sensitive OBSID's, 
         # run through each observation and append either "*FP SENS*" or
         # "NOT FP SENS" to the end of each observation. 
-        #
-        # Create an empty observation list which will hold the results. This
-        # list contains all ACIS and all CTI observations and will have the 
-        # sensitivity boolean added.
-        obs_with_sensitivity = []
     
         # Now run through the observation list attribute of the ObsidFindFilter class
         for eachobservation in acis_and_cti_obs:
@@ -345,7 +287,7 @@ class ACISFPCheck(ACISThermalCheck):
             else:
                 eachobservation.append(False)
     
-            obs_with_sensitivity.append(eachobservation)
+            self.obs_with_sensitivity.append(eachobservation)
     
         #
         # create an empty dictionary called plots to contain the returned 
@@ -406,7 +348,7 @@ class ACISFPCheck(ACISThermalCheck):
             endcapstop = -109.0
             textypos = -108.0
             fontsize = 12
-            draw_obsids(extract_and_filter, obs_with_sensitivity, self.nopref_array,
+            draw_obsids(extract_and_filter, self.obs_with_sensitivity, self.nopref_array,
                         plots, msid+"_1", ypos, endcapstart, endcapstop, textypos, 
                         fontsize, plot_start)
             # Build the file name and output the plot to a file
@@ -457,7 +399,7 @@ class ACISFPCheck(ACISThermalCheck):
             endcapstop = ypos - 0.05
             textypos = ypos + 0.05
             fontsize = 9
-            draw_obsids(extract_and_filter, obs_with_sensitivity, self.nopref_array,
+            draw_obsids(extract_and_filter, self.obs_with_sensitivity, self.nopref_array,
                         plots, msid+"_2", ypos, endcapstart, endcapstop, textypos, 
                         fontsize, plot_start)
             # Build the file name and output the file
@@ -509,7 +451,7 @@ class ACISFPCheck(ACISThermalCheck):
             textypos = -115.7
             fontsize = 9
     
-            draw_obsids(extract_and_filter, obs_with_sensitivity, self.nopref_array,
+            draw_obsids(extract_and_filter, self.obs_with_sensitivity, self.nopref_array,
                         plots, msid+"_3", ypos, endcapstart, endcapstop, textypos, 
                         fontsize, plot_start)
     
@@ -592,10 +534,9 @@ class ACISFPCheck(ACISThermalCheck):
         plots['roll']['fig'].savefig(outfile)
         plots['roll']['filename'] = filename
 
-        return plots, obs_with_sensitivity
+        return plots
 
-    def make_prediction_viols(self, states, times, temps, load_start,
-                              obs_with_sensitivity):
+    def make_prediction_viols(self, times, temps, load_start):
         """
         Find limit violations where predicted temperature is above the
         red minus margin.
@@ -628,9 +569,10 @@ class ACISFPCheck(ACISThermalCheck):
 
         """
         mylog.info('\nMAKE VIOLS Checking for limit violations in ' +
-                   str(len(states)) + ' states and\n ' +
-                   str(len(obs_with_sensitivity)) +
+                   str(len(self.obs_with_sensitivity)) +
                    " total science observations")
+
+        viols = {}
 
         # create an instance of ObsidFindFilter()
         eandf = ObsidFindFilter()
@@ -639,13 +581,13 @@ class ACISFPCheck(ACISThermalCheck):
         #   Create subsets of all the observations
         # ------------------------------------------------------
         # Just the CTI runs
-        cti_only_obs = eandf.cti_only_filter(obs_with_sensitivity)
+        cti_only_obs = eandf.cti_only_filter(self.obs_with_sensitivity)
         # Now divide out observations by ACIS-S and ACIS-I
-        ACIS_S_obs = eandf.get_all_specific_instrument(obs_with_sensitivity, "ACIS-S")
-        ACIS_I_obs = eandf.get_all_specific_instrument(obs_with_sensitivity, "ACIS-I")
+        ACIS_S_obs = eandf.get_all_specific_instrument(self.obs_with_sensitivity, "ACIS-S")
+        ACIS_I_obs = eandf.get_all_specific_instrument(self.obs_with_sensitivity, "ACIS-I")
 
         # ACIS SCIENCE observations only  - no HRC; no CTI
-        non_cti_obs = eandf.cti_filter(obs_with_sensitivity)
+        non_cti_obs = eandf.cti_filter(self.obs_with_sensitivity)
 
         # ACIS SCIENCE OBS which are sensitive to FP TEMP
         fp_sens_only_obs = eandf.fp_sens_filter(non_cti_obs)
@@ -669,8 +611,8 @@ class ACISFPCheck(ACISThermalCheck):
         # Collect any -118.7C violations of CTI runs. These are not
         # load killers but need to be reported
 
-        cti_viols = search_obsids_for_viols(self.msid, self.name, self.fp_sens_limit,
-                                            cti_only_obs, temp, times, load_start)
+        viols["cti"] = search_obsids_for_viols(self.msid, self.name, self.fp_sens_limit,
+                                               cti_only_obs, temp, times, load_start)
 
         # ------------------------------------------------------------
         #  FP TEMP sensitive observations; -118.7 violation check
@@ -678,9 +620,9 @@ class ACISFPCheck(ACISThermalCheck):
         # ------------------------------------------------------------
         mylog.info('\n\nFP SENSITIVE -118.7 SCIENCE ONLY violations')
 
-        fp_sens_viols = search_obsids_for_viols(self.msid, self.name, self.fp_sens_limit,
-                                                fp_sense_without_noprefs, temp, times,
-                                                load_start)
+        viols["fp_sens"] = search_obsids_for_viols(self.msid, self.name, self.fp_sens_limit,
+                                                   fp_sense_without_noprefs, temp, times,
+                                                   load_start)
 
         # --------------------------------------------------------------
         #  ACIS-S - Collect any -112C violations of any non-CTI ACIS-S science run.
@@ -689,8 +631,8 @@ class ACISFPCheck(ACISThermalCheck):
         #
         mylog.info('\n\n ACIS-S -112 SCIENCE ONLY violations')
 
-        ACIS_S_viols = search_obsids_for_viols(self.msid, self.name, self.acis_s_limit,
-                                               ACIS_S_obs, temp, times, load_start)
+        viols["ACIS_S"] = search_obsids_for_viols(self.msid, self.name, self.acis_s_limit,
+                                                  ACIS_S_obs, temp, times, load_start)
 
         # --------------------------------------------------------------
         #  ACIS-I - Collect any -114C violations of any non-CTI ACIS science run.
@@ -700,10 +642,10 @@ class ACISFPCheck(ACISThermalCheck):
         mylog.info('\n\n ACIS-I -114 SCIENCE ONLY violations')
 
         # Create the violation data structure.
-        ACIS_I_viols = search_obsids_for_viols(self.msid, self.name, self.acis_i_limit,
-                                               ACIS_I_obs, temp, times, load_start)
+        viols["ACIS_I"] = search_obsids_for_viols(self.msid, self.name, self.acis_i_limit,
+                                                  ACIS_I_obs, temp, times, load_start)
 
-        return ACIS_I_viols, ACIS_S_viols, cti_viols, fp_sens_viols
+        return viols
 
     def get_histogram_mask(self, tlm, limit):
         """

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -261,44 +261,35 @@ class ACISFPCheck(ACISThermalCheck):
                     plots=plots, ACIS_I_viols=viols[0], ACIS_S_viols=viols[1],
                     cti_viols=viols[2], fp_sens_viols=viols[3])
 
-    def driver(self, args, state_builder):
+    def driver(self):
         """
         The main interface to all of ACISFPCheck's functions.
         This method must be called by the particular thermal model
         implementation to actually run the code and make the webpage.
-
-        Parameters
-        ----------
-        args : ArgumentParser arguments
-            The command-line options object, which has the options
-            attached to it as attributes
-        state_builder : StateBuilder object
-            The StateBuilder object used to construct commanded states
         """
-        self.state_builder = state_builder
-        self.fps_nopref = args.fps_nopref
+        self.fps_nopref = self.args.fps_nopref
 
-        proc = self._setup_proc_and_logger(args)
+        proc = self._setup_proc_and_logger(self.args)
 
-        is_weekly_load = args.backstop_file is not None
-        tstart, tstop, tnow = self._determine_times(args.run_start,
+        is_weekly_load = self.args.backstop_file is not None
+        tstart, tstop, tnow = self._determine_times(self.args.run_start,
                                                     is_weekly_load)
 
         # Get the telemetry values which will be used
         # for prediction and validation
-        tlm = self.get_telem_values(min(tstart, tnow), days=args.days)
+        tlm = self.get_telem_values(min(tstart, tnow), days=self.args.days)
 
         # make predictions on a backstop file if defined
-        if args.backstop_file is not None:
-            pred = self.make_week_predict(tstart, tstop, tlm, args.T_init,
-                                          args.model_spec, args.outdir)
+        if self.args.backstop_file is not None:
+            pred = self.make_week_predict(tstart, tstop, tlm, self.args.T_init,
+                                          self.args.model_spec, self.args.outdir)
         else:
             pred = defaultdict(lambda: None)
 
         # Validation
         # Make the validation plots
-        plots_validation = self.make_validation_plots(tlm, args.model_spec,
-                                                      args.outdir, args.run_start)
+        plots_validation = self.make_validation_plots(tlm, self.args.model_spec,
+                                                      self.args.outdir, self.args.run_start)
 
         # Determine violations of temperature validation
         valid_viols = self.make_validation_viols(plots_validation)
@@ -306,12 +297,12 @@ class ACISFPCheck(ACISThermalCheck):
         # if you found some violations....
         if len(valid_viols) > 0:
             # generate daily plot url if outdir in expected year/day format
-            daymatch = re.match('.*(\d{4})/(\d{3})', args.outdir)
+            daymatch = re.match('.*(\d{4})/(\d{3})', self.args.outdir)
             if self.bsdir is None and daymatch:
                 url = os.path.join(URL, daymatch.group(1), daymatch.group(2))
                 mylog.info('validation warning(s) at %s' % url)
             else:
-                mylog.info('validation warning(s) in output at %s' % args.outdir)
+                mylog.info('validation warning(s) in output at %s' % self.args.outdir)
 
         # Write everything to the web page.
         # First, write the reStructuredText file.
@@ -329,11 +320,11 @@ class ACISFPCheck(ACISThermalCheck):
 
         template_path = os.path.join(model_path, 'templates')
 
-        self.write_index_rst(self.bsdir, args.outdir, context, 
+        self.write_index_rst(self.bsdir, self.args.outdir, context, 
                              template_path=template_path)
 
         # Second, convert reST to HTML
-        self.rst_to_html(args.outdir, proc)
+        self.rst_to_html(self.args.outdir, proc)
 
         return
 

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -21,7 +21,7 @@ import glob
 from Ska.Matplotlib import pointpair, \
     cxctime2plotdate
 import Ska.engarchive.fetch_sci as fetch
-from Chandra.Time import DateTime, date2secs
+from Chandra.Time import DateTime
 from collections import defaultdict
 import numpy as np
 import xija

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -58,16 +58,18 @@ MSID = {"acisfp": "FPTEMP"}
 YELLOW = None
 MARGIN = None
 
+fp_sens, acis_i, acis_s = get_acis_limits("fptemp")
+
 # This is the cutoff temperature for any FPTEMP sensitive observation
 # if the FP temp goes above this number, and the obswervation is sensitive to
 # the focal plane temperature, it has to be flagged
-FP_TEMP_SENSITIVE = {"acisfp": -118.7}
+FP_TEMP_SENSITIVE = {"acisfp": fp_sens}
 
 # This is the new maximum temperature for all ACIS-S observations (4/26/16)
-ACIS_S_RED = {"acisfp": -112.0}
+ACIS_S_RED = {"acisfp": acis_s}
 
 # ACIS-I max temperatures remain at -114 deg. C
-ACIS_I_RED = {"acisfp": -114.0}
+ACIS_I_RED = {"acisfp": acis_i}
 
 VALIDATION_LIMITS = {'PITCH': [(1, 3.0), (99, 3.0)],
                      'TSCPOS': [(1, 2.5), (99, 2.5)]

--- a/acisfp_check/templates/index_template.rst
+++ b/acisfp_check/templates/index_template.rst
@@ -16,7 +16,7 @@ Summary
 ====================  =============================================
 Date start            {{proc.datestart}}
 Date stop             {{proc.datestop}}
-FP_TEMP status        {%if ACIS_I_viols.fptemp or ACIS_S_viols.fptemp %}:red:`NOT OK`{% else %}OK{% endif%} 
+FP_TEMP status        {%if viols.ACIS_I.fptemp or viols.ACIS_S.fptemp %}:red:`NOT OK`{% else %}OK{% endif%} 
 {% if bsdir %}
 Load directory        {{bsdir}}
 {% endif %}
@@ -32,7 +32,7 @@ ACIS-I FP_TEMP -114 deg C Violations
 =====================  =====================  ==================  ==================
 Date start             Date stop              Max temperature     Obsids
 =====================  =====================  ==================  ==================
-{% for viol in ACIS_I_viols.fptemp %}
+{% for viol in viols.ACIS_I.fptemp %}
 {{viol.datestart}}  {{viol.datestop}}  {{"%.2f"|format(viol.maxtemp)}}            {{viol.obsid}}
 {% endfor %}
 =====================  =====================  ==================  ==================
@@ -47,7 +47,7 @@ ACIS-S FP_TEMP -112 deg C Violations
 =====================  =====================  ==================  ==================
 Date start             Date stop              Max temperature     Obsids
 =====================  =====================  ==================  ==================
-{% for viol in ACIS_S_viols.fptemp %}
+{% for viol in viols.ACIS_S.fptemp %}
 {{viol.datestart}}  {{viol.datestop}}  {{"%.2f"|format(viol.maxtemp)}}            {{viol.obsid}}
 {% endfor %}
 =====================  =====================  ==================  ==================
@@ -56,13 +56,13 @@ No ACIS-S -112 deg C FP_TEMP Violations
 {% endif %}
 
 
-{% if fp_sens_viols.fptemp %}
+{% if viols.fp_sens.fptemp %}
 FP TEMP Sensitive, -118.7 deg. C Preference Not Met:
 -------------------------------------------------------------------
 =====================  =====================  ==================  ==================
 Date start             Date stop              Max temperature     OBSID
 =====================  =====================  ==================  ==================
-{% for viol in fp_sens_viols.fptemp %}
+{% for viol in viols.fp_sens.fptemp %}
 {{viol.datestart}}  {{viol.datestop}}  {{"%.2f"|format(viol.maxtemp)}}             {{viol.obsid}}
 {% endfor %}
 =====================  =====================  ==================  ==================
@@ -72,13 +72,13 @@ No Focal Plane Sensitive Observation -118.7 deg C FP_TEMP Preferences Unmet
 
 
 
-{% if cti_viols.fptemp %}
+{% if viols.cti.fptemp %}
 FP_TEMP -118.7 deg C Violations for Perigee Passages
 -------------------------------------------------------------------
 =====================  =====================  ==================
 Date start             Date stop              Max temperature
 =====================  =====================  ==================
-{% for viol in cti_viols.fptemp %}
+{% for viol in viols.cti.fptemp %}
 {{viol.datestart}}  {{viol.datestop}}  {{"%.2f"|format(viol.maxtemp)}}
 {% endfor %}
 =====================  =====================  ==================

--- a/acisfp_check/templates/index_template.rst
+++ b/acisfp_check/templates/index_template.rst
@@ -26,7 +26,7 @@ Temperatures          `<temperatures.dat>`_
 States                `<states.dat>`_
 ====================  =============================================
 
-{% if ACIS_I_viols.fptemp %}
+{% if viols.ACIS_I.fptemp %}
 ACIS-I FP_TEMP -114 deg C Violations
 ------------------------------------
 =====================  =====================  ==================  ==================
@@ -41,7 +41,7 @@ No ACIS-I -114 deg C FP_TEMP Violations
 {% endif %}
 
 
-{% if ACIS_S_viols.fptemp %}
+{% if viols.ACIS_S.fptemp %}
 ACIS-S FP_TEMP -112 deg C Violations
 ------------------------------------
 =====================  =====================  ==================  ==================

--- a/acisfp_check/tests/conftest.py
+++ b/acisfp_check/tests/conftest.py
@@ -1,0 +1,2 @@
+from acis_thermal_check.regression_testing import \
+    pytest_addoption, answer_store

--- a/acisfp_check/tests/test_acisfp.py
+++ b/acisfp_check/tests/test_acisfp.py
@@ -1,0 +1,16 @@
+from ..acisfp_check import VALIDATION_LIMITS, \
+    HIST_LIMIT, calc_model, model_path, ACISFPCheck
+from acis_thermal_check.regression_testing import \
+    RegressionTester
+
+atc_kwargs = {"other_telem": ['1dahtbon'],
+              "other_map": {'1dahtbon': 'dh_heater',
+                            "fptemp_11": "fptemp"}}
+
+acisfp_rt = RegressionTester("fptemp", "acisfp", model_path, VALIDATION_LIMITS,
+                             HIST_LIMIT, calc_model, atc_class=ACISFPCheck,
+                             atc_kwargs=atc_kwargs)
+
+def test_acisfp_loads(answer_store):
+    acisfp_rt.run_test_arrays(answer_store)
+


### PR DESCRIPTION
This PR provides the updates to `acisfp_check` to make it work with the new version of `acis_thermal_check` (PR acisops/acis_thermal_check#14). The result is a simplified code base and improved support for regression testing.

Highlights:

1. A number of logic has been refactored into private methods so that we do not have to overload as many methods of `ACISThermalCheck`, which resulted in considerable code duplication.
2. The various limits are obtained using the `get_acis_limits` function internally in `ACISThermalCheck` and no longer need to be kept in this script.
3. It is no longer necessary for the script to construct the `StateBuilder` object as this now happens internally in `ACISThermalCheck`.
4. A regression test has been added which tests model outputs against validated answers for a number of loads.