### PR TITLE
March 2019 recalibration of FP model

### DIFF
--- a/acisfp_check/__init__.py
+++ b/acisfp_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.4.0"
+__version__ = "2.5.0"
 
 from .acisfp_check import \
     ACISFPCheck, calc_model

--- a/acisfp_check/acisfp_model_spec.json
+++ b/acisfp_check/acisfp_model_spec.json
@@ -1,1147 +1,1247 @@
 {
     "bad_times": [
         [
-            "2014:187:23:36:36", 
+            "2014:187:23:36:36",
             "2014:189:00:00:00"
-        ], 
+        ],
         [
-            "2014:207:07:03:55", 
+            "2014:207:07:03:55",
             "2014:208:23:57:00"
-        ], 
+        ],
         [
-            "2014:356:04:52:35", 
+            "2014:356:04:52:35",
             "2014:356:22:57:00"
-        ], 
+        ],
         [
-            "2014:357:11:36:38", 
+            "2014:357:11:36:38",
             "2014:358:18:30:01"
-        ], 
+        ],
         [
-            "2015:006:08:24:00", 
+            "2015:006:08:24:00",
             "2015:009:03:06:08"
-        ], 
+        ],
         [
-            "2015:012:00:43:26", 
+            "2015:012:00:43:26",
             "2015:013:13:30:00"
-        ], 
+        ],
         [
-            "2015:076:04:37:42", 
+            "2015:076:04:37:42",
             "2015:078:03:11:26"
+        ],
+        [
+            "2018:283:12:00:00",
+            "2018:296:12:00:00"
         ]
-    ], 
+    ],
     "comps": [
         {
-            "class_name": "Pitch", 
-            "init_args": [], 
-            "init_kwargs": {}, 
+            "class_name": "Pitch",
+            "init_args": [],
+            "init_kwargs": {},
             "name": "pitch"
-        }, 
+        },
         {
-            "class_name": "Roll", 
-            "init_args": [], 
-            "init_kwargs": {}, 
+            "class_name": "Roll",
+            "init_args": [],
+            "init_kwargs": {},
             "name": "roll"
-        }, 
+        },
         {
-            "class_name": "DetectorHousingHeater", 
-            "init_args": [], 
-            "init_kwargs": {}, 
+            "class_name": "DetectorHousingHeater",
+            "init_args": [],
+            "init_kwargs": {},
             "name": "dh_heater"
-        }, 
+        },
         {
-            "class_name": "Eclipse", 
-            "init_args": [], 
-            "init_kwargs": {}, 
+            "class_name": "Eclipse",
+            "init_args": [],
+            "init_kwargs": {},
             "name": "eclipse"
-        }, 
+        },
         {
-            "class_name": "SimZ", 
-            "init_args": [], 
-            "init_kwargs": {}, 
+            "class_name": "SimZ",
+            "init_args": [],
+            "init_kwargs": {},
             "name": "sim_z"
-        }, 
+        },
         {
-            "class_name": "MaskBox", 
+            "class_name": "MaskBox",
             "init_args": [
-                "fptemp", 
-                -120.5, 
+                "fptemp",
+                -120.5,
                 -116.0
-            ], 
-            "init_kwargs": {}, 
+            ],
+            "init_kwargs": {},
             "name": "maskbox__fptemp"
-        }, 
+        },
         {
-            "class_name": "Node", 
+            "class_name": "Node",
             "init_args": [
                 "fptemp_11"
-            ], 
+            ],
             "init_kwargs": {
-                "mask": "maskbox__fptemp", 
+                "mask": "maskbox__fptemp",
                 "name": "fptemp"
-            }, 
+            },
             "name": "fptemp"
-        }, 
+        },
         {
-            "class_name": "CmdStatesData", 
+            "class_name": "CmdStatesData",
             "init_args": [
                 "fep_count"
-            ], 
-            "init_kwargs": {}, 
+            ],
+            "init_kwargs": {},
             "name": "fep_count"
-        }, 
+        },
         {
-            "class_name": "CmdStatesData", 
+            "class_name": "CmdStatesData",
             "init_args": [
                 "ccd_count"
-            ], 
-            "init_kwargs": {}, 
+            ],
+            "init_kwargs": {},
             "name": "ccd_count"
-        }, 
+        },
         {
-            "class_name": "CmdStatesData", 
+            "class_name": "CmdStatesData",
             "init_args": [
                 "vid_board"
-            ], 
-            "init_kwargs": {}, 
+            ],
+            "init_kwargs": {},
             "name": "vid_board"
-        }, 
+        },
         {
-            "class_name": "CmdStatesData", 
+            "class_name": "CmdStatesData",
             "init_args": [
                 "clocking"
-            ], 
-            "init_kwargs": {}, 
+            ],
+            "init_kwargs": {},
             "name": "clocking"
-        }, 
+        },
         {
-            "class_name": "AcisDpaStatePower", 
+            "class_name": "AcisDpaStatePower",
             "init_args": [
                 "fptemp"
-            ], 
+            ],
             "init_kwargs": {
-                "ccd_count": "ccd_count", 
-                "clocking": "clocking", 
-                "fep_count": "fep_count", 
-                "mult": 0.020363, 
+                "ccd_count": "ccd_count",
+                "clocking": "clocking",
+                "fep_count": "fep_count",
+                "mult": 0.020363,
                 "pow_states": [
-                    "0xxx", 
-                    "1xxx", 
-                    "2xxx", 
-                    "3xx0", 
-                    "3xx1", 
-                    "4xxx", 
-                    "55x0", 
-                    "5xxx", 
-                    "66x0", 
-                    "6611", 
-                    "6xxx"
-                ], 
+                    "0xxx",
+                    "30xx",
+                    "1xxx",
+                    "2xxx",
+                    "3xx0",
+                    "3xx1",
+                    "4xxx",
+                    "5xx0",
+                    "5xx1",
+                    "6xx0",
+                    "6xx1"
+                ],
                 "vid_board": "vid_board"
-            }, 
+            },
             "name": "dpa_power"
-        }, 
+        },
         {
-            "class_name": "TelemData", 
+            "class_name": "TelemData",
             "init_args": [
                 "aoattqt1"
-            ], 
+            ],
             "init_kwargs": {
-                "fetch_attr": "midvals", 
+                "fetch_attr": "midvals",
                 "mval": false
-            }, 
+            },
             "name": "aoattqt1"
-        }, 
+        },
         {
-            "class_name": "TelemData", 
+            "class_name": "TelemData",
             "init_args": [
                 "aoattqt2"
-            ], 
+            ],
             "init_kwargs": {
-                "fetch_attr": "midvals", 
+                "fetch_attr": "midvals",
                 "mval": false
-            }, 
+            },
             "name": "aoattqt2"
-        }, 
+        },
         {
-            "class_name": "TelemData", 
+            "class_name": "TelemData",
             "init_args": [
                 "aoattqt3"
-            ], 
+            ],
             "init_kwargs": {
-                "fetch_attr": "midvals", 
+                "fetch_attr": "midvals",
                 "mval": false
-            }, 
+            },
             "name": "aoattqt3"
-        }, 
+        },
         {
-            "class_name": "TelemData", 
+            "class_name": "TelemData",
             "init_args": [
                 "aoattqt4"
-            ], 
+            ],
             "init_kwargs": {
-                "fetch_attr": "midvals", 
+                "fetch_attr": "midvals",
                 "mval": false
-            }, 
+            },
             "name": "aoattqt4"
-        }, 
+        },
         {
-            "class_name": "TelemData", 
+            "class_name": "TelemData",
             "init_args": [
                 "orbitephem0_x"
-            ], 
+            ],
             "init_kwargs": {
                 "mval": false
-            }, 
+            },
             "name": "orbitephem0_x"
-        }, 
+        },
         {
-            "class_name": "TelemData", 
+            "class_name": "TelemData",
             "init_args": [
                 "orbitephem0_y"
-            ], 
+            ],
             "init_kwargs": {
                 "mval": false
-            }, 
+            },
             "name": "orbitephem0_y"
-        }, 
+        },
         {
-            "class_name": "TelemData", 
+            "class_name": "TelemData",
             "init_args": [
                 "orbitephem0_z"
-            ], 
+            ],
             "init_kwargs": {
                 "mval": false
-            }, 
+            },
             "name": "orbitephem0_z"
-        }, 
+        },
         {
-            "class_name": "EarthHeat", 
+            "class_name": "EarthHeat",
             "init_args": [
                 "fptemp"
-            ], 
+            ],
             "init_kwargs": {
-                "aoattqt1": "aoattqt1", 
-                "aoattqt2": "aoattqt2", 
-                "aoattqt3": "aoattqt3", 
-                "aoattqt4": "aoattqt4", 
-                "orbitephem0_x": "orbitephem0_x", 
-                "orbitephem0_y": "orbitephem0_y", 
+                "aoattqt1": "aoattqt1",
+                "aoattqt2": "aoattqt2",
+                "aoattqt3": "aoattqt3",
+                "aoattqt4": "aoattqt4",
+                "orbitephem0_x": "orbitephem0_x",
+                "orbitephem0_y": "orbitephem0_y",
                 "orbitephem0_z": "orbitephem0_z"
-            }, 
+            },
             "name": "earthheat__fptemp"
-        }, 
+        },
         {
-            "class_name": "ThermostatHeater", 
+            "class_name": "ThermostatHeater",
             "init_args": [
                 "fptemp"
-            ], 
+            ],
             "init_kwargs": {
-                "P": 0.1, 
+                "P": 0.1,
                 "T_set": -120.0
-            }, 
+            },
             "name": "thermostat_heat__fptemp"
-        }, 
+        },
         {
-            "class_name": "HeatSink", 
+            "class_name": "HeatSink",
             "init_args": [
                 "fptemp"
-            ], 
+            ],
             "init_kwargs": {
-                "T": -150.0, 
+                "T": -150.0,
                 "tau": 20.0
-            }, 
+            },
             "name": "heatsink__fptemp"
-        }, 
+        },
         {
-            "class_name": "Node", 
+            "class_name": "Node",
             "init_args": [
                 "sim_px"
-            ], 
+            ],
             "init_kwargs": {
-                "data": -132.0, 
+                "data": -132.0,
                 "sigma": 0
-            }, 
+            },
             "name": "sim_px"
-        }, 
+        },
         {
-            "class_name": "HeatSink", 
+            "class_name": "HeatSink",
             "init_args": [
                 "sim_px"
-            ], 
+            ],
             "init_kwargs": {
-                "T": -132.0, 
+                "T": -132.0,
                 "tau": 20.0
-            }, 
+            },
             "name": "heatsink__sim_px"
-        }, 
+        },
         {
-            "class_name": "SolarHeatHrc", 
+            "class_name": "SolarHeatHrcOpts",
             "init_args": [
-                "sim_px", 
-                "sim_z", 
-                "pitch", 
+                "sim_px",
+                "sim_z",
+                "pitch",
                 "eclipse"
-            ], 
+            ],
             "init_kwargs": {
                 "P_pitches": [
-                    45, 
-                    70, 
-                    90, 
-                    120, 
-                    130, 
-                    140, 
-                    150, 
-                    160
-                ], 
+                    45,
+                    70,
+                    90,
+                    120,
+                    130,
+                    140,
+                    150,
+                    160,
+                    170,
+                    180
+                ],
                 "Ps": [
-                    0.0, 
-                    0.0, 
-                    0.0, 
-                    0.0, 
-                    0.0, 
-                    0.0, 
-                    0.0, 
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
                     0.0
-                ], 
-                "epoch": "2017:177", 
+                ],
+                "epoch": "2017:177",
                 "var_func": "linear"
-            }, 
+            },
             "name": "solarheat__sim_px"
-        }, 
+        },
         {
-            "class_name": "SolarHeatOffNomRoll", 
+            "class_name": "SolarHeatOffNomRoll",
             "init_args": [
                 "sim_px"
-            ], 
+            ],
             "init_kwargs": {
-                "P_minus_y": 0.0, 
-                "P_plus_y": 0.0, 
-                "eclipse_comp": "eclipse", 
-                "pitch_comp": "pitch", 
+                "P_minus_y": 0.0,
+                "P_plus_y": 0.0,
+                "eclipse_comp": "eclipse",
+                "pitch_comp": "pitch",
                 "roll_comp": "roll"
-            }, 
+            },
             "name": "solarheat_off_nom_roll__sim_px"
-        }, 
+        },
         {
-            "class_name": "Coupling", 
+            "class_name": "Coupling",
             "init_args": [
-                "fptemp", 
+                "fptemp",
                 "sim_px"
-            ], 
+            ],
             "init_kwargs": {
                 "tau": 50.0
-            }, 
+            },
             "name": "coupling__fptemp__sim_px"
-        }, 
+        },
         {
-            "class_name": "Node", 
+            "class_name": "Node",
             "init_args": [
                 "1cbat"
-            ], 
+            ],
             "init_kwargs": {
                 "sigma": 0
-            }, 
+            },
             "name": "1cbat"
-        }, 
+        },
         {
-            "class_name": "Coupling", 
+            "class_name": "Coupling",
             "init_args": [
-                "fptemp", 
+                "fptemp",
                 "1cbat"
-            ], 
+            ],
             "init_kwargs": {
                 "tau": 18
-            }, 
+            },
             "name": "coupling__fptemp__1cbat"
-        }, 
+        },
         {
-            "class_name": "SolarHeatAcisCameraBody", 
+            "class_name": "SolarHeatAcisCameraBody",
             "init_args": [
                 "1cbat"
-            ], 
+            ],
             "init_kwargs": {
                 "P_pitches": [
-                    45, 
-                    70, 
-                    90, 
-                    120, 
-                    130, 
-                    140, 
-                    150, 
-                    160
-                ], 
+                    45,
+                    70,
+                    90,
+                    120,
+                    130,
+                    140,
+                    150,
+                    160,
+                    170,
+                    180
+                ],
                 "Ps": [
-                    0.0, 
-                    0.0, 
-                    0.0, 
-                    0.0, 
-                    0.0, 
-                    0.0, 
-                    0.0, 
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
                     0.0
-                ], 
-                "dh_heater_comp": "dh_heater", 
-                "eclipse_comp": "eclipse", 
-                "epoch": "2017:177", 
-                "pitch_comp": "pitch", 
+                ],
+                "dh_heater_comp": "dh_heater",
+                "eclipse_comp": "eclipse",
+                "epoch": "2017:177",
+                "pitch_comp": "pitch",
                 "var_func": "linear"
-            }, 
+            },
             "name": "solarheat__1cbat"
-        }, 
+        },
         {
-            "class_name": "SolarHeatOffNomRoll", 
+            "class_name": "SolarHeatOffNomRoll",
             "init_args": [
                 "1cbat"
-            ], 
+            ],
             "init_kwargs": {
-                "P_minus_y": 0.0, 
-                "P_plus_y": 0.0, 
-                "eclipse_comp": "eclipse", 
-                "pitch_comp": "pitch", 
+                "P_minus_y": 0.0,
+                "P_plus_y": 0.0,
+                "eclipse_comp": "eclipse",
+                "pitch_comp": "pitch",
                 "roll_comp": "roll"
-            }, 
+            },
             "name": "solarheat_off_nom_roll__1cbat"
-        }, 
+        },
         {
-            "class_name": "HeatSinkRef", 
+            "class_name": "HeatSinkRef",
             "init_args": [
                 "1cbat"
-            ], 
-            "init_kwargs": {}, 
+            ],
+            "init_kwargs": {},
             "name": "heatsink__1cbat"
         }
-    ], 
-    "datestart": "2016:361:12:02:48.816", 
-    "datestop": "2017:359:23:53:52.816", 
-    "dt": 328.0, 
+    ],
+    "datestart": "2018:079:12:01:50.816",
+    "datestop": "2019:013:23:52:38.816",
+    "dt": 328.0,
     "gui_config": {
-        "filename": "/home/jzuhone/acisfp_spec_new.json", 
+        "filename": "/home/jzuhone/acisfp_model_spec_mar0419.json",
         "plot_names": [
-            "fptemp data__time", 
-            "fptemp resid__time", 
-            "earthheat__fptemp data__time", 
-            "ccd_count data__time", 
-            "pitch data__time"
-        ], 
-        "set_data_vals": {}, 
+            "fptemp data__time",
+            "solarheat__sim_px solar_heat__pitch",
+            "solarheat__1cbat solar_heat__pitch"
+        ],
+        "set_data_vals": {},
         "size": [
-            2040, 
-            1202
+            2122,
+            1085
         ]
-    }, 
-    "mval_names": [], 
-    "name": "acisfp", 
+    },
+    "mval_names": [],
+    "name": "acisfp",
     "pars": [
         {
-            "comp_name": "maskbox__fptemp", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "maskbox__fptemp__val0", 
-            "max": 1000, 
-            "min": -1000, 
-            "name": "val0", 
+            "comp_name": "maskbox__fptemp",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "maskbox__fptemp__val0",
+            "max": 1000,
+            "min": -1000,
+            "name": "val0",
             "val": -120.0
-        }, 
+        },
         {
-            "comp_name": "maskbox__fptemp", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "maskbox__fptemp__val1", 
-            "max": 1000, 
-            "min": -1000, 
-            "name": "val1", 
+            "comp_name": "maskbox__fptemp",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "maskbox__fptemp__val1",
+            "max": 1000,
+            "min": -1000,
+            "name": "val1",
             "val": -104.0
-        }, 
+        },
         {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__pow_0xxx", 
-            "max": 60, 
-            "min": 10, 
-            "name": "pow_0xxx", 
-            "val": 10.474327039092024
-        }, 
+            "comp_name": "dpa_power",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "dpa_power__pow_0xxx",
+            "max": 60,
+            "min": 10,
+            "name": "pow_0xxx",
+            "val": 13.351426483535917
+        },
         {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__pow_1xxx", 
-            "max": 60, 
-            "min": 15, 
-            "name": "pow_1xxx", 
-            "val": 24.734841372825947
-        }, 
+            "comp_name": "dpa_power",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "dpa_power__pow_30xx",
+            "max": 60,
+            "min": 10,
+            "name": "pow_30xx",
+            "val": 46.927772602136265
+        },
         {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__pow_2xxx", 
-            "max": 80, 
-            "min": 20, 
-            "name": "pow_2xxx", 
-            "val": 31.217247191323189
-        }, 
+            "comp_name": "dpa_power",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "dpa_power__pow_1xxx",
+            "max": 60,
+            "min": 15,
+            "name": "pow_1xxx",
+            "val": 17.270031738402494
+        },
         {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__pow_3xx0", 
-            "max": 100, 
-            "min": 20, 
-            "name": "pow_3xx0", 
-            "val": 52.0
-        }, 
+            "comp_name": "dpa_power",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "dpa_power__pow_2xxx",
+            "max": 80,
+            "min": 20,
+            "name": "pow_2xxx",
+            "val": 28.662943513755163
+        },
         {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": false, 
-            "full_name": "dpa_power__pow_3xx1", 
-            "max": 100, 
-            "min": 20, 
-            "name": "pow_3xx1", 
-            "val": 52.0
-        }, 
+            "comp_name": "dpa_power",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "dpa_power__pow_3xx0",
+            "max": 100,
+            "min": 20,
+            "name": "pow_3xx0",
+            "val": 34.07961818380424
+        },
         {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__pow_4xxx", 
-            "max": 120, 
-            "min": 20, 
-            "name": "pow_4xxx", 
-            "val": 62.0
-        }, 
+            "comp_name": "dpa_power",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "dpa_power__pow_3xx1",
+            "max": 100,
+            "min": 20,
+            "name": "pow_3xx1",
+            "val": 48.05746675864994
+        },
         {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__pow_55x0", 
-            "max": 120, 
-            "min": 20, 
-            "name": "pow_55x0", 
-            "val": 65.459562796627779
-        }, 
+            "comp_name": "dpa_power",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "dpa_power__pow_4xxx",
+            "max": 120,
+            "min": 20,
+            "name": "pow_4xxx",
+            "val": 55.49138673399938
+        },
         {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__pow_5xxx", 
-            "max": 120, 
-            "min": 20, 
-            "name": "pow_5xxx", 
-            "val": 64.686146031306805
-        }, 
+            "comp_name": "dpa_power",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "dpa_power__pow_5xx0",
+            "max": 120,
+            "min": 20,
+            "name": "pow_5xx0",
+            "val": 80.06887433359073
+        },
         {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__pow_66x0", 
-            "max": 140, 
-            "min": 20, 
-            "name": "pow_66x0", 
-            "val": 48.605105651436972
-        }, 
+            "comp_name": "dpa_power",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "dpa_power__pow_5xx1",
+            "max": 120,
+            "min": 20,
+            "name": "pow_5xx1",
+            "val": 61.31251412428851
+        },
         {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__pow_6611", 
-            "max": 140, 
-            "min": 20, 
-            "name": "pow_6611", 
-            "val": 72.223038724556176
-        }, 
+            "comp_name": "dpa_power",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "dpa_power__pow_6xx0",
+            "max": 140,
+            "min": 20,
+            "name": "pow_6xx0",
+            "val": 48.402958764382184
+        },
         {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__pow_6xxx", 
-            "max": 140, 
-            "min": 20, 
-            "name": "pow_6xxx", 
-            "val": 78.883216914149955
-        }, 
+            "comp_name": "dpa_power",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "dpa_power__pow_6xx1",
+            "max": 140,
+            "min": 20,
+            "name": "pow_6xx1",
+            "val": 73.32128035649097
+        },
         {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__mult", 
-            "max": 2.0, 
-            "min": 0.0, 
-            "name": "mult", 
-            "val": 0.33316274901241005
-        }, 
+            "comp_name": "dpa_power",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "dpa_power__mult",
+            "max": 2.0,
+            "min": 0.0,
+            "name": "mult",
+            "val": 0.24845610809067853
+        },
         {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__bias", 
-            "max": 100, 
-            "min": 10, 
-            "name": "bias", 
-            "val": 70.0
-        }, 
+            "comp_name": "dpa_power",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "dpa_power__bias",
+            "max": 100,
+            "min": 10,
+            "name": "bias",
+            "val": 71.22404229471228
+        },
         {
-            "comp_name": "earthheat__fptemp", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "earthheat__fptemp__k", 
-            "max": 20.0, 
-            "min": 0.0, 
-            "name": "k", 
-            "val": 7.9358965326778899
-        }, 
+            "comp_name": "earthheat__fptemp",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "earthheat__fptemp__k",
+            "max": 20.0,
+            "min": 0.0,
+            "name": "k",
+            "val": 7.570890863382298
+        },
         {
-            "comp_name": "thermostat_heat__fptemp", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "thermostat_heat__fptemp__P", 
-            "max": 3.0, 
-            "min": 0.0, 
-            "name": "P", 
+            "comp_name": "thermostat_heat__fptemp",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "thermostat_heat__fptemp__P",
+            "max": 3.0,
+            "min": 0.0,
+            "name": "P",
             "val": 0.5109834628343255
-        }, 
+        },
         {
-            "comp_name": "thermostat_heat__fptemp", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "thermostat_heat__fptemp__T_set", 
-            "max": -115.0, 
-            "min": -126.0, 
-            "name": "T_set", 
+            "comp_name": "thermostat_heat__fptemp",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "thermostat_heat__fptemp__T_set",
+            "max": -115.0,
+            "min": -126.0,
+            "name": "T_set",
             "val": -119.6200683570855
-        }, 
+        },
         {
-            "comp_name": "heatsink__fptemp", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "heatsink__fptemp__T", 
-            "max": -100.0, 
-            "min": -200.0, 
-            "name": "T", 
+            "comp_name": "heatsink__fptemp",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "heatsink__fptemp__T",
+            "max": -100.0,
+            "min": -200.0,
+            "name": "T",
             "val": -194.0118039255176
-        }, 
+        },
         {
-            "comp_name": "heatsink__fptemp", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "heatsink__fptemp__tau", 
-            "max": 80.0, 
-            "min": 10.0, 
-            "name": "tau", 
-            "val": 47.74743732360303
-        }, 
+            "comp_name": "heatsink__fptemp",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "heatsink__fptemp__tau",
+            "max": 80.0,
+            "min": 10.0,
+            "name": "tau",
+            "val": 48.00907531698713
+        },
         {
-            "comp_name": "heatsink__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "heatsink__sim_px__T", 
-            "max": -130.0, 
-            "min": -135.0, 
-            "name": "T", 
+            "comp_name": "heatsink__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "heatsink__sim_px__T",
+            "max": -130.0,
+            "min": -135.0,
+            "name": "T",
             "val": -131.08394915114567
-        }, 
+        },
         {
-            "comp_name": "heatsink__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "heatsink__sim_px__tau", 
-            "max": 70.0, 
-            "min": 10.0, 
-            "name": "tau", 
-            "val": 28.472941477749284
-        }, 
+            "comp_name": "heatsink__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "heatsink__sim_px__tau",
+            "max": 70.0,
+            "min": 10.0,
+            "name": "tau",
+            "val": 28.025577318322362
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__P_45", 
-            "max": 1.0, 
-            "min": -1.754746871726422, 
-            "name": "P_45", 
-            "val": -0.98753682394290654
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__P_45",
+            "max": 1.0,
+            "min": -1.754746871726422,
+            "name": "P_45",
+            "val": -0.8246377243689892
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__P_70", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "P_70", 
-            "val": -0.62239995321533614
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__P_70",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "P_70",
+            "val": -0.16952276591173784
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__P_90", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "P_90", 
-            "val": 0.061039327347185063
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__P_90",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "P_90",
+            "val": -0.681867188655965
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__P_120", 
-            "max": 1.5844461609727976, 
-            "min": -1.0, 
-            "name": "P_120", 
-            "val": 1.5660450148177265
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__P_120",
+            "max": 1.5844461609727976,
+            "min": -1.0,
+            "name": "P_120",
+            "val": 1.5435064326956551
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__P_130", 
-            "max": 1.5844461609727976, 
-            "min": -1.0, 
-            "name": "P_130", 
-            "val": 1.5472702131270806
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__P_130",
+            "max": 1.5844461609727976,
+            "min": -1.0,
+            "name": "P_130",
+            "val": 1.5012255713015046
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__P_140", 
-            "max": 2.1045379301743674, 
-            "min": -1.0, 
-            "name": "P_140", 
-            "val": 2.0039561520224556
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__P_140",
+            "max": 2.1045379301743674,
+            "min": -1.0,
+            "name": "P_140",
+            "val": 2.002463746250391
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__P_150", 
-            "max": 2.425811798375036, 
-            "min": -1.0, 
-            "name": "P_150", 
-            "val": 2.3342304356965928
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__P_150",
+            "max": 2.425811798375036,
+            "min": -1.0,
+            "name": "P_150",
+            "val": 2.406549177920951
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__P_160", 
-            "max": 1.9489430048399385, 
-            "min": -1.0, 
-            "name": "P_160", 
-            "val": 1.9109066905902776
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__P_160",
+            "max": 1.9489430048399385,
+            "min": -1.0,
+            "name": "P_160",
+            "val": 1.9013873035525146
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__dP_45", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_45", 
-            "val": -0.82082332470639852
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "solarheat__sim_px__P_170",
+            "max": 1.9489430048399385,
+            "min": -1.0,
+            "name": "P_170",
+            "val": 1.8552020647106386
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__dP_70", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_70", 
-            "val": -0.15513180758974163
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "solarheat__sim_px__P_180",
+            "max": 1.9489430048399385,
+            "min": -1.0,
+            "name": "P_180",
+            "val": 1.855
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__dP_90", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_90", 
-            "val": -0.077099766838500658
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__dP_45",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_45",
+            "val": -0.6036634648264368
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__dP_120", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_120", 
-            "val": 0.64627021593094525
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__dP_70",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_70",
+            "val": -0.30420714905944457
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__dP_130", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_130", 
-            "val": 0.3876670865679146
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__dP_90",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_90",
+            "val": -0.11832452865248716
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__dP_140", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_140", 
-            "val": 0.69127141796141234
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__dP_120",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_120",
+            "val": 0.5607718216396173
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__dP_150", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_150", 
-            "val": 0.27366690150594447
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__dP_130",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_130",
+            "val": 0.4115910891946748
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__dP_160", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_160", 
-            "val": 0.51869963127652841
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__dP_140",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_140",
+            "val": 0.6857980294562616
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__tau", 
-            "max": 3000.0, 
-            "min": 20.0, 
-            "name": "tau", 
-            "val": 366.6383166322363
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__dP_150",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_150",
+            "val": 0.29207830537233537
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__ampl", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "ampl", 
-            "val": -0.12529353237048643
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__dP_160",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_160",
+            "val": 0.5416440952904673
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__bias", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "bias", 
-            "val": 0.0035792094895159489
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "solarheat__sim_px__dP_170",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_170",
+            "val": 0.6550085152212186
+        },
         {
-            "comp_name": "solarheat__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__sim_px__hrc_bias", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "hrc_bias", 
-            "val": -0.61872660616298158
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "solarheat__sim_px__dP_180",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_180",
+            "val": 0.655
+        },
         {
-            "comp_name": "solarheat_off_nom_roll__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat_off_nom_roll__sim_px__P_plus_y", 
-            "max": 5.0, 
-            "min": -5.0, 
-            "name": "P_plus_y", 
-            "val": -1.1324593357820587
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__tau",
+            "max": 3000.0,
+            "min": 20.0,
+            "name": "tau",
+            "val": 367.80353015158835
+        },
         {
-            "comp_name": "solarheat_off_nom_roll__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat_off_nom_roll__sim_px__P_minus_y", 
-            "max": 5.0, 
-            "min": -5.0, 
-            "name": "P_minus_y", 
-            "val": 2.4776020996745984
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__ampl",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "ampl",
+            "val": -0.14745055692304587
+        },
         {
-            "comp_name": "coupling__fptemp__sim_px", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "coupling__fptemp__sim_px__tau", 
-            "max": 150.0, 
-            "min": 50.0, 
-            "name": "tau", 
-            "val": 140.85981019676569
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__bias",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "bias",
+            "val": 0.08145539650599962
+        },
         {
-            "comp_name": "coupling__fptemp__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "coupling__fptemp__1cbat__tau", 
-            "max": 80.0, 
-            "min": 20.0, 
-            "name": "tau", 
-            "val": 43.430499924960614
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__hrci_bias",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "hrci_bias",
+            "val": -0.45358158179675667
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__P_45", 
-            "max": 0.2, 
-            "min": -0.2, 
-            "name": "P_45", 
-            "val": 0.030038139524411409
-        }, 
+            "comp_name": "solarheat__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__sim_px__hrcs_bias",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "hrcs_bias",
+            "val": -0.6993024689808998
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__P_70", 
-            "max": 0.2, 
-            "min": -0.2, 
-            "name": "P_70", 
-            "val": 0.044584460425444755
-        }, 
+            "comp_name": "solarheat_off_nom_roll__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat_off_nom_roll__sim_px__P_plus_y",
+            "max": 5.0,
+            "min": -5.0,
+            "name": "P_plus_y",
+            "val": -1.1943224123796496
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__P_90", 
-            "max": 0.2, 
-            "min": -0.2, 
-            "name": "P_90", 
-            "val": -0.040700261767571758
-        }, 
+            "comp_name": "solarheat_off_nom_roll__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat_off_nom_roll__sim_px__P_minus_y",
+            "max": 5.0,
+            "min": -5.0,
+            "name": "P_minus_y",
+            "val": 2.5851791075255317
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__P_120", 
-            "max": 0.2, 
-            "min": -0.2, 
-            "name": "P_120", 
-            "val": -0.056253556086109754
-        }, 
+            "comp_name": "coupling__fptemp__sim_px",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "coupling__fptemp__sim_px__tau",
+            "max": 150.0,
+            "min": 50.0,
+            "name": "tau",
+            "val": 140.74921449364072
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__P_130", 
-            "max": 0.2, 
-            "min": -0.2, 
-            "name": "P_130", 
-            "val": 0.15468890253218445
-        }, 
+            "comp_name": "coupling__fptemp__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "coupling__fptemp__1cbat__tau",
+            "max": 80.0,
+            "min": 20.0,
+            "name": "tau",
+            "val": 43.43137883121062
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__P_140", 
-            "max": 0.2085877068595628, 
-            "min": -0.2, 
-            "name": "P_140", 
-            "val": 0.12867728287734109
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__P_45",
+            "max": 0.2,
+            "min": -0.2,
+            "name": "P_45",
+            "val": 0.020652645538312277
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__P_150", 
-            "max": 0.2, 
-            "min": -0.2, 
-            "name": "P_150", 
-            "val": 0.11870593474701617
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__P_70",
+            "max": 0.2,
+            "min": -0.2,
+            "name": "P_70",
+            "val": 0.034478579025276346
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__P_160", 
-            "max": 0.2, 
-            "min": -0.2, 
-            "name": "P_160", 
-            "val": 0.19044475016894397
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__P_90",
+            "max": 0.2,
+            "min": -0.2,
+            "name": "P_90",
+            "val": 0.03333969247531106
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__dP_45", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_45", 
-            "val": 0.45732199677561869
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__P_120",
+            "max": 0.2,
+            "min": -0.2,
+            "name": "P_120",
+            "val": -0.04593427612343128
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__dP_70", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_70", 
-            "val": -0.08133508755825003
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__P_130",
+            "max": 0.2,
+            "min": -0.2,
+            "name": "P_130",
+            "val": 0.15772814375791078
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__dP_90", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_90", 
-            "val": -0.056913393780116311
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__P_140",
+            "max": 0.2085877068595628,
+            "min": -0.2,
+            "name": "P_140",
+            "val": 0.13161600619356548
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__dP_120", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_120", 
-            "val": -0.19155044553919845
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__P_150",
+            "max": 0.2,
+            "min": -0.2,
+            "name": "P_150",
+            "val": 0.11950525077953601
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__dP_130", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_130", 
-            "val": -0.15795937075973018
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__P_160",
+            "max": 0.2,
+            "min": -0.2,
+            "name": "P_160",
+            "val": 0.18562694495930793
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__dP_140", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_140", 
-            "val": -0.29265248723424592
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "solarheat__1cbat__P_170",
+            "max": 0.2,
+            "min": -0.2,
+            "name": "P_170",
+            "val": 0.17573416975451361
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__dP_150", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_150", 
-            "val": -0.048535063119985219
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "solarheat__1cbat__P_180",
+            "max": 0.2,
+            "min": -0.2,
+            "name": "P_180",
+            "val": 0.1757
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__dP_160", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_160", 
-            "val": 0.032116799879658472
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__dP_45",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_45",
+            "val": 0.46844003523856265
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__tau", 
-            "max": 3000.0, 
-            "min": 1000.0, 
-            "name": "tau", 
-            "val": 1732.6964984907136
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__dP_70",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_70",
+            "val": 0.0844273354051264
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__ampl", 
-            "max": 0.2, 
-            "min": -0.2, 
-            "name": "ampl", 
-            "val": 0.039456548825243541
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__dP_90",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_90",
+            "val": 0.09501821185360014
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__bias", 
-            "max": 0.2, 
-            "min": -0.2, 
-            "name": "bias", 
-            "val": 0.0073783598039861772
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__dP_120",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_120",
+            "val": 0.00250424199293325
+        },
         {
-            "comp_name": "solarheat__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__1cbat__dh_heater_bias", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "dh_heater_bias", 
-            "val": 0.010984823705016326
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__dP_130",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_130",
+            "val": -0.2169463391695549
+        },
         {
-            "comp_name": "solarheat_off_nom_roll__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat_off_nom_roll__1cbat__P_plus_y", 
-            "max": 5.0, 
-            "min": -5.0, 
-            "name": "P_plus_y", 
-            "val": 0.32731969999868993
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__dP_140",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_140",
+            "val": -0.31559470708630843
+        },
         {
-            "comp_name": "solarheat_off_nom_roll__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat_off_nom_roll__1cbat__P_minus_y", 
-            "max": 5.0, 
-            "min": -5.0, 
-            "name": "P_minus_y", 
-            "val": -0.64658642305143155
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__dP_150",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_150",
+            "val": -0.04629673800794472
+        },
         {
-            "comp_name": "heatsink__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "heatsink__1cbat__P", 
-            "max": 10.0, 
-            "min": -1.0, 
-            "name": "P", 
-            "val": 0.14184619083176886
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__dP_160",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_160",
+            "val": -0.16180993601919297
+        },
         {
-            "comp_name": "heatsink__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "heatsink__1cbat__tau", 
-            "max": 80.0, 
-            "min": 20.0, 
-            "name": "tau", 
-            "val": 62.767259454709176
-        }, 
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "solarheat__1cbat__dP_170",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_170",
+            "val": -0.0411228676625505
+        },
         {
-            "comp_name": "heatsink__1cbat", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "heatsink__1cbat__T_ref", 
-            "max": 100, 
-            "min": -100, 
-            "name": "T_ref", 
-            "val": -68.615384615384613
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "solarheat__1cbat__dP_180",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_180",
+            "val": -0.04112
+        },
+        {
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__tau",
+            "max": 3000.0,
+            "min": 1000.0,
+            "name": "tau",
+            "val": 1735.151799664454
+        },
+        {
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__ampl",
+            "max": 0.2,
+            "min": -0.2,
+            "name": "ampl",
+            "val": 0.04043157211787009
+        },
+        {
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__bias",
+            "max": 0.2,
+            "min": -0.2,
+            "name": "bias",
+            "val": 4.6153397450503664e-05
+        },
+        {
+            "comp_name": "solarheat__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__1cbat__dh_heater_bias",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dh_heater_bias",
+            "val": 0.3306359893205616
+        },
+        {
+            "comp_name": "solarheat_off_nom_roll__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat_off_nom_roll__1cbat__P_plus_y",
+            "max": 5.0,
+            "min": -5.0,
+            "name": "P_plus_y",
+            "val": 0.31451887393746936
+        },
+        {
+            "comp_name": "solarheat_off_nom_roll__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat_off_nom_roll__1cbat__P_minus_y",
+            "max": 5.0,
+            "min": -5.0,
+            "name": "P_minus_y",
+            "val": -0.6581643566488721
+        },
+        {
+            "comp_name": "heatsink__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "heatsink__1cbat__P",
+            "max": 10.0,
+            "min": -1.0,
+            "name": "P",
+            "val": 0.1403426161307658
+        },
+        {
+            "comp_name": "heatsink__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "heatsink__1cbat__tau",
+            "max": 80.0,
+            "min": 20.0,
+            "name": "tau",
+            "val": 62.64290210718152
+        },
+        {
+            "comp_name": "heatsink__1cbat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "heatsink__1cbat__T_ref",
+            "max": 100,
+            "min": -100,
+            "name": "T_ref",
+            "val": -68.48769720982584
         }
-    ], 
+    ],
     "tlm_code": null
 }


### PR DESCRIPTION
This recalibration of the FP thermal model was approved at the TWG on March 5, 2019. Main highlights are:

* Recently, a critical bug was patched in the acis_taco software, which is used by the FP model to calculate the contribution to the temperature from the bright Earth in the ACIS radiator field of view. This fact alone necessitates a recalibration.
* Power coefficients for the ACIS state power component have been updated to more accurately reflect the actual power states on board the spacecraft.
* The SolarHeat component of this model had one “bias” parameter when HRC was in the focal plane. Like the other ACIS models, this recalibration now includes two such parameters, one for the HRC-I position and one for the HRC-S position.
* Added pitch bins at 170, 180 degrees to begin to fit recent high pitches
* General recalibration of parameters

Dashboard plots:

Old model, science observations only:

![fp_jan19_old_norz](https://user-images.githubusercontent.com/1914976/53907337-f5e0f980-401a-11e9-8203-4f122bb9231f.png)

New model, science observations only:

![fp_jan19_new_norz](https://user-images.githubusercontent.com/1914976/53907356-fed1cb00-401a-11e9-940e-659554f56f6a.png)
