### PR TITLE
Edit plot y-axis upper limit to allow for more space for new thermal limits

### DIFF
--- a/acisfp_check/__init__.py
+++ b/acisfp_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.5.0"
+__version__ = "2.6.0"
 
 from .acisfp_check import \
     ACISFPCheck, calc_model

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -347,7 +347,7 @@ class ACISFPCheck(ACISThermalCheck):
         w1 = None
         # Make plots of FPTEMP and pitch vs time, looping over
         # three different temperature ranges
-        ylim = [(-120, -90), (-120, -119), (-120.0, -111.5)]
+        ylim = [(-120, -90), (-120, -119), (-120.0, -109.5)]
         ypos = [-110.0, -119.35, -116]
         capwidth = [2.0, 0.1, 0.4]
         textypos = [-108.0, -119.3, -115.7]

--- a/acisfp_check/templates/index_template.rst
+++ b/acisfp_check/templates/index_template.rst
@@ -28,7 +28,7 @@ States                `<states.dat>`_
 ====================  =============================================
 
 {% if viols.ACIS_I.fptemp %}
-ACIS-I FP_TEMP -114 deg C Violations
+ACIS-I FP_TEMP -112 deg C Violations
 ------------------------------------
 =====================  =====================  ==================  ==================
 Date start             Date stop              Max temperature     Obsids
@@ -43,7 +43,7 @@ No ACIS-I -114 deg C FP_TEMP Violations
 
 
 {% if viols.ACIS_S.fptemp %}
-ACIS-S FP_TEMP -112 deg C Violations
+ACIS-S FP_TEMP -111 deg C Violations
 ------------------------------------
 =====================  =====================  ==================  ==================
 Date start             Date stop              Max temperature     Obsids


### PR DESCRIPTION
We are raising the ACIS-I and ACIS-S thermal limits, and in order to see the higher temperatures and the ACIS-S limit at -111 C we need to raise the upper limit on the y-axis for the first prediction plot. 

See also https://github.com/acisops/acis_thermal_check/pull/22.