### PR TITLE
Replacing Chandra.Time with CxoTime

### DIFF
--- a/acisfp_check/__init__.py
+++ b/acisfp_check/__init__.py
@@ -5,3 +5,11 @@ __version__ = ska_helpers.get_version(__package__)
 from .acisfp_check import \
     ACISFPCheck, main, \
     model_path
+
+
+def test(*args, **kwargs):
+    """
+    Run py.test unit tests.
+    """
+    import testr
+    return testr.test(*args, **kwargs)

--- a/acisfp_check/acis_obs.py
+++ b/acisfp_check/acis_obs.py
@@ -15,10 +15,9 @@
 #                        of states from the Commanded States Data base
 #
 ###############################################################################
-from Chandra.Time import DateTime
 import cheta.fetch_sci as fetch
 from Ska.DBI import DBI
-
+from cxotime import CxoTime
 #----------------------------------------------------------------
 #
 # who_in_fp.py
@@ -148,8 +147,8 @@ class ObsidFindFilter():
 
         """
         # convert begin and end into sybase query tstart and tstop
-        tstart = DateTime(tbegin)
-        tstop = DateTime(tend)
+        tstart = CxoTime(tbegin)
+        tstop = CxoTime(tend)
         #
         # form the query for everything, starting from tstart date to now
         #
@@ -282,12 +281,12 @@ class ObsidFindFilter():
                firstpow is None:
                 firstpow = eachstate
                 DOYfetchstart = eachstate.datestart
-                secsfetchstart = DateTime(DOYfetchstart).secs
+                secsfetchstart = CxoTime(DOYfetchstart).secs
 
             # Process the first XTZ0000005 line you see
             if (eachstate.power_cmd == 'XTZ0000005' or eachstate.power_cmd == 'XCZ0000005') and \
                (xtztime is None and firstpow is not None):
-                xtztime = DateTime(eachstate.datestart).secs
+                xtztime = CxoTime(eachstate.datestart).secs
 
             # Process the first NPNT line you see
             if obsid is None and firstpow is not None:
@@ -316,9 +315,9 @@ class ObsidFindFilter():
 
             # Process the first AA00000000 line you see
             if eachstate.power_cmd == 'AA00000000' and aa0time is None and firstpow is not None:
-                aa0time = DateTime(eachstate.datestart).secs
+                aa0time = CxoTime(eachstate.datestart).secs
                 DOYfetchstop = eachstate.datestop
-                secsfetchstop = DateTime(DOYfetchstop).secs
+                secsfetchstop = CxoTime(DOYfetchstop).secs
 
                 # now calculate the exposure time
                 if xtztime is not None:

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -19,7 +19,7 @@ matplotlib.use('Agg')
 import glob
 from Ska.Matplotlib import pointpair, \
     cxctime2plotdate
-from Chandra.Time import DateTime, secs2date
+from cxotime import CxoTime
 from collections import defaultdict
 import numpy as np
 from acis_thermal_check import \
@@ -523,7 +523,7 @@ class ACISFPCheck(ACISThermalCheck):
         outfile = os.path.join(outdir, 'earth_solid_angles.dat')
         mylog.info('Writing Earth solid angles to %s' % outfile)
         e = self.predict_model.comp['earthheat__fptemp'].dvals
-        efov_table = Table([times, secs2date(times), e],
+        efov_table = Table([times, CxoTime(times).date, e],
                            names=['time', 'date', 'earth_solid_angle'],
                            copy=False)
         efov_table['time'].format = '%.2f'
@@ -557,9 +557,9 @@ def paint_perigee(perigee_passages, states, plots, msid):
         # The index [1] item is always the Perigee Passage time. Draw that line in red
         # If this line is between tstart and tstop then it needs to be drawn
         # on the plot. otherwise ignore
-        if states['tstop'][-1] >= DateTime(eachpassage[0]).secs >= states['tstart'][0]:
+        if states['tstop'][-1] >= CxoTime(eachpassage[0]).secs >= states['tstart'][0]:
             # Have to convert this time into the new x axis time scale necessitated by SKA
-            xpos = cxctime2plotdate([DateTime(eachpassage[0]).secs])
+            xpos = cxctime2plotdate([CxoTime(eachpassage[0]).secs])
 
             ymin, ymax = plots[msid]['ax'].get_ylim()
 
@@ -568,7 +568,7 @@ def paint_perigee(perigee_passages, states, plots, msid):
 
             # Plot the perigee passage time so long as it was specified in the CTI_report file
             if eachpassage[1] != "Not-within-load":
-                perigee_time = cxctime2plotdate([DateTime(eachpassage[1]).secs])
+                perigee_time = cxctime2plotdate([CxoTime(eachpassage[1]).secs])
                 plots[msid]['ax'].vlines(perigee_time, ymin, ymax, linestyle=':',
                                          color='black', linewidth=2.0)
 


### PR DESCRIPTION
## Description

This PR replaces the use of `Chandra.Time` for computing CXC times with `CxoTime`. 

## Testing

- [x] Passes unit tests on macOS 
- [ ] Functional testing