### PR TITLE
Changes for ACIS-S observations to -109 C, track ECS observations in the science orbit and catch violations

### DIFF
--- a/acisfp_check/acis_obs.py
+++ b/acisfp_check/acis_obs.py
@@ -471,7 +471,7 @@ class ObsidFindFilter():
         # check the SIMODE of the interval. If it is 50k or greater, it's
         # an ECS observation and we want to remove those from our list
         for eachinterval in obsidinterval_list:
-            if eachinterval[self.obsid] < 50000:
+            if eachinterval[self.obsid] < 60000:
                 self.non_ECS_obs.append(eachinterval)
 
         return self.non_ECS_obs
@@ -610,7 +610,7 @@ class ObsidFindFilter():
         """
         ecs_only = []
         for eachobservation in obsidinterval_list:
-            if eachobservation[self.obsid] >= 50000 and \
+            if eachobservation[self.obsid] >= 60000 and \
                eachobservation[self.in_focal_plane] == "HRC-S":
                 ecs_only.append(eachobservation)
         return ecs_only

--- a/acisfp_check/acis_obs.py
+++ b/acisfp_check/acis_obs.py
@@ -7,7 +7,7 @@
 #
 #                        These filters are: Exposure time range
 #                                           CCD Count range
-#                                           CTI observation removal
+#                                           ECS observation removal
 #                                           Pitch range
 #
 #
@@ -101,7 +101,7 @@ class ObsidFindFilter():
         # But that may change in the future.
         self.cmd_states = None
         self.obsid_interval_list = None
-        self.non_CTI_obs = None
+        self.non_ECS_obs = None
 
         self.list_of_sensitive_obs = []
 
@@ -440,13 +440,13 @@ class ObsidFindFilter():
 
     #---------------------------------------------------------------------
     #
-    #   CTI_filter
+    #   ECS_filter
     #
     #---------------------------------------------------------------------
-    def cti_filter(self, obsidinterval_list):
+    def ecs_filter(self, obsidinterval_list):
         """
         Given a list of obsid intervals, remove any obsid
-                     interval which is a CTI observation (i.e. has 
+                     interval which is an ECS observation (i.e. has 
                      an OBSID greater than 50k).
                    - return the filtered list
                      specified and return those intervals as a list.
@@ -465,19 +465,16 @@ class ObsidFindFilter():
                        filespec = <some file path> or " "
                        cmd_states = cmd_statesFetch(start_time, stop_time)
                        obsid_intervals = FindObsidIntervals(cmd_states, filespec)
-
-                       Non_cti_intervals = CTIFilter(OBSIDIntervals)
-
         """
-        self.non_CTI_obs = []
+        self.non_ECS_obs = []
 
-        # check the OBSID of the interval. If it is 50k or greater, it's
-        # a CTI observation and we want to remove those from our list
+        # check the SIMODE of the interval. If it is 50k or greater, it's
+        # an ECS observation and we want to remove those from our list
         for eachinterval in obsidinterval_list:
             if eachinterval[self.obsid] < 50000:
-                self.non_CTI_obs.append(eachinterval)
+                self.non_ECS_obs.append(eachinterval)
 
-        return self.non_CTI_obs
+        return self.non_ECS_obs
  
     #---------------------------------------------------------------------
     #
@@ -592,31 +589,31 @@ class ObsidFindFilter():
         HRC-I" or HRC-S" as the science instrument, AND an obsid LESS THAN 
         50,000
         """
-        acis_and_cti_only = []
+        acis_and_ecs_only = []
         for eachobservation in obsidinterval_list:
             if eachobservation[self.in_focal_plane].startswith("ACIS-") or \
                eachobservation[self.obsid] >= 50000:
-                acis_and_cti_only.append(eachobservation)
-        return acis_and_cti_only
+                acis_and_ecs_only.append(eachobservation)
+        return acis_and_ecs_only
 
 
     #--------------------------------------------------------------------------
     #
-    #   cti_only_filter
+    #   ecs_only_filter
     #
     #--------------------------------------------------------------------------
-    def cti_only_filter(self, obsidinterval_list):
+    def ecs_only_filter(self, obsidinterval_list):
         """
         This method will filter out any science observation from the 
         input obsid interval list.It keeps any observation that has an
         obsid of 50,000 or greater
         """
-        cti_only = []
+        ecs_only = []
         for eachobservation in obsidinterval_list:
             if eachobservation[self.obsid] >= 50000 and \
                eachobservation[self.in_focal_plane] == "HRC-S":
-                cti_only.append(eachobservation)
-        return cti_only
+                ecs_only.append(eachobservation)
+        return ecs_only
 
 
     #--------------------------------------------------------------------------
@@ -645,11 +642,11 @@ class ObsidFindFilter():
     #
     #---------------------------------------------------------------------
     def general_g_i(self, start_time='2011:001', stop_time=None, 
-                    exptime=None, noCTI=False, pitchrange=None): 
+                    exptime=None, noECS=False, pitchrange=None): 
         """
         Given: A Start and Stop time
                Exposure time range (e.g. [10000, 50000])
-               CTI include flag (True/False)
+               ECS include flag (True/False)
                Pitch range [low, high]
  
         Return:  Get all the obsid intervals between start_time
@@ -685,23 +682,23 @@ class ObsidFindFilter():
             print("general_g_i Step 3 - No exposure time filtering")
         print("Number of Observation Intervals found within the time filter: ", len(ei))
 
-        # Step 4 - Filter out all CTI observations if required
-        if noCTI == True:
-            print("\ngeneral_g_i Step 4 - Filter out all CTI observations")
-            no_cti = self.cti_filter(ei)
+        # Step 4 - Filter out all ECS observations if required
+        if noECS:
+            print("\ngeneral_g_i Step 4 - Filter out all ECS observations")
+            no_ecs = self.ecs_filter(ei)
         else:
-            print("\ngeneral_g_i Step 4 - *SKIPPED* Filter out all CTI "
+            print("\ngeneral_g_i Step 4 - *SKIPPED* Filter out all ECS "
                   "observations - SKIPPED")
-            no_cti = ei
-        print("Number of observations after CTI's processing (or not) is: ", len(no_cti))
+            no_ecs = ei
+        print("Number of observations after ECS's processing (or not) is: ", len(no_ecs))
 
         # Step 5 - Filter based upon pitch if a pitch range is given
         if pitchrange != []:
             print("\ngeneral_g_i Step 5 - Filtering on pitches in the range: ", pitchrange)
-            pitchlist = self.pitch_filter(no_cti, pitchrange)
+            pitchlist = self.pitch_filter(no_ecs, pitchrange)
         else:
             print("\ngeneral_g_i Step 5 - NO Filtering on pitches")
-            pitchlist = no_cti
+            pitchlist = no_ecs
 
         print("\n\ngeneral_g_i -----Final number of obsid's filtered is: ", len(pitchlist))
 

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -610,7 +610,7 @@ def draw_obsids(extract_and_filter,
         obsid = extract_and_filter.get_obsid(eachobservation)
         in_fp = eachobservation[extract_and_filter.in_focal_plane]
 
-        if obsid > 50000:
+        if obsid > 60000:
             # ECS observations during the science orbit are colored blue
             color = 'blue'
         else:
@@ -624,14 +624,14 @@ def draw_obsids(extract_and_filter,
         obsid_txt = str(obsid)
         # If this is an ECS measurement in the science orbit mark
         # it as such
-        if obsid > 50000:
+        if obsid > 60000:
             obsid_txt += " (ECS)"
 
         # Convert the start and stop times into the Ska-required format
         obs_start = cxctime2plotdate([extract_and_filter.get_tstart(eachobservation)])
         obs_stop = cxctime2plotdate([extract_and_filter.get_tstop(eachobservation)])
 
-        if in_fp.startswith("ACIS-") or obsid > 50000:
+        if in_fp.startswith("ACIS-") or obsid > 60000:
             # For each ACIS Obsid, draw a horizontal line to show
             # its start and stop
             plots[msid]['ax'].hlines(ypos, 

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -54,7 +54,10 @@ class ACISFPCheck(ACISThermalCheck):
                                           other_map={'1dahtbon': 'dh_heater',
                                                      "fptemp_11": "fptemp"})
         # Set specific limits for the focal plane model
-        self.fp_sens_limit, self.acis_i_limit, self.acis_s_limit = \
+        self.fp_sens_limit, \
+        self.acis_i_limit, \
+        self.acis_s_limit,\
+        self.acis_hot_limit = \
             get_acis_limits("fptemp")
         self.obs_with_sensitivity = None
         self.perigee_passages = None
@@ -332,7 +335,7 @@ class ACISFPCheck(ACISThermalCheck):
         w1 = None
         # Make plots of FPTEMP and pitch vs time, looping over
         # three different temperature ranges
-        ylim = [(-120, -90), (-120, -119), (-120.0, -109.5)]
+        ylim = [(-120, -90), (-120, -119), (-120.0, -107.5)]
         ypos = [-110.0, -119.35, -116]
         capwidth = [2.0, 0.1, 0.4]
         textypos = [-108.0, -119.3, -115.7]
@@ -345,15 +348,17 @@ class ACISFPCheck(ACISThermalCheck):
                                    title=self.msid.upper() + " (ACIS-I obs. in red; ACIS-S in green)",
                                    xlabel='Date', ylabel='Temperature (C)',
                                    ylabel2='Pitch (deg)', xmin=plot_start,
-                                   ylim=ylim[i], ylim2=(40, 180),
+                                   ylim=ylim[i], ylim2=(40, 180), 
+                                   figsize=(12, 7.142857142857142),
                                    width=w1, load_start=load_start)
             # Draw a horizontal line indicating the FP Sensitive Observation Cut off
-            plots[name]['ax'].axhline(self.fp_sens_limit, linestyle='--', color='red', linewidth=2.0)
+            plots[name]['ax'].axhline(self.fp_sens_limit, linestyle='--', color='dodgerblue', linewidth=2.0)
             # Draw a horizontal line showing the ACIS-I -114 deg. C cutoff
-            plots[name]['ax'].axhline(self.acis_i_limit, linestyle='--', color='purple', linewidth=1.0)
+            plots[name]['ax'].axhline(self.acis_i_limit, linestyle='--', color='purple', linewidth=2.0)
             # Draw a horizontal line showing the ACIS-S -112 deg. C cutoff
-            plots[name]['ax'].axhline(self.acis_s_limit, linestyle='--', color='blue', linewidth=1.0)
-
+            plots[name]['ax'].axhline(self.acis_s_limit, linestyle='--', color='blue', linewidth=2.0)
+            # Draw a horizontal line showing the ACIS-S -109 deg. C cutoff
+            plots[name]['ax'].axhline(self.acis_hot_limit, linestyle='--', color='red', linewidth=2.0)
             # Get the width of this plot to make the widths of all the
             # prediction plots the same
             if i == 0:

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -344,7 +344,7 @@ class ACISFPCheck(ACISThermalCheck):
             plots[name] = plot_two(fig_id=i+1, x=times, y=temps[self.name],
                                    x2=self.predict_model.times,
                                    y2=self.predict_model.comp["pitch"].mvals,
-                                   title=self.msid.upper() + " (ACIS-I obs. in red; ACIS-S in green)",
+                                   title=f"{self.msid.upper()} (ACIS-I in red; ACIS-S in green; ECS in blue)",
                                    xlabel='Date', ylabel='Temperature (C)',
                                    ylabel2='Pitch (deg)', xmin=plot_start,
                                    ylim=ylim[i], ylim2=(40, 180), 
@@ -581,13 +581,11 @@ def draw_obsids(extract_and_filter,
                 plot_start):
     """
     This function draws visual indicators across the top of the plot showing
-    which observations are ACIS; whether they are ACIS-I (red) or ACIS-S (green)
-    when they start and stop, and whether or not any observation is sensitive to the
-    focal plane temperature.  The list of observations sensitive to the focal plane
-    is found by reading the fp_sensitive.dat file that is located in each LR
-    directory and is created by the LR script.
-
-    No ECS measurements are indicated - only science runs.
+    which observations are ACIS; whether they are ACIS-I (red), ACIS-S (green),
+    or ECS (blue); when they start and stop; and whether or not any observation 
+    is sensitive to the focal plane temperature. The list of observations sensitive 
+    to the focal plane is found by reading the fp_sensitive.dat file that is 
+    located in each LR directory and is created by the LR script.
 
     The caller supplies:
                Options from the Command line supplied by the user at runtime
@@ -605,20 +603,25 @@ def draw_obsids(extract_and_filter,
     for eachobservation in obs_with_sensitivity:
         # extract the obsid
 
-        obsid = str(extract_and_filter.get_obsid(eachobservation))
+        obsid = extract_and_filter.get_obsid(eachobservation)
+        in_fp = eachobservation[extract_and_filter.in_focal_plane]
 
-        # Color all ACIS-S observations green; all ACIS-I 
-        # observations red
-        if eachobservation[extract_and_filter.in_focal_plane] == "ACIS-I":
-            color = 'red'
+        if obsid > 50000:
+            # ECS observations during the science orbit are colored blue
+            color = 'blue'
         else:
-            color = 'green'
+            # Color all ACIS-S observations green; all ACIS-I
+            # observations red
+            if in_fp == "ACIS-I":
+                color = 'red'
+            else:
+                color = 'green'
 
         # Convert the start and stop times into the Ska-required format
         obs_start = cxctime2plotdate([extract_and_filter.get_tstart(eachobservation)])
         obs_stop = cxctime2plotdate([extract_and_filter.get_tstop(eachobservation)])
 
-        if eachobservation[extract_and_filter.in_focal_plane].startswith("ACIS-"):
+        if in_fp.startswith("ACIS-") or obsid > 50000:
             # For each ACIS Obsid, draw a horizontal line to show 
             # its start and stop
             plots[msid]['ax'].hlines(ypos, 
@@ -649,11 +652,11 @@ def draw_obsids(extract_and_filter,
                 plots[msid]['ax'].text(obs_time, 
                                        textypos, 
                                        obsid,  
-                                       color = color, 
+                                       color=color, 
                                        va='bottom', 
                                        ma='left', 
-                                       rotation = 90, 
-                                       fontsize = fontsize)
+                                       rotation=90, 
+                                       fontsize=fontsize)
 
 
 def main():

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -623,13 +623,6 @@ def draw_obsids(extract_and_filter,
         else:
             color = 'green'
 
-        # Add the sensitivity text if the observation was found to be FP TEMP
-        # sensitive
-        #
-        # If the observation is FP sensitive in the first place............
-        if eachobservation[extract_and_filter.is_fp_sensitive]:
-            obsid = obsid + ' * FP SENS *'
-
         # Convert the start and stop times into the Ska-required format
         obs_start = cxctime2plotdate([extract_and_filter.get_tstart(eachobservation)])
         obs_stop = cxctime2plotdate([extract_and_filter.get_tstop(eachobservation)])

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -46,7 +46,7 @@ class ACISFPCheck(ACISThermalCheck):
         valid_limits = {'PITCH': [(1, 3.0), (99, 3.0)],
                         'TSCPOS': [(1, 2.5), (99, 2.5)]
                         }
-        hist_limit = [(-120.0, -112.0)]
+        hist_limit = [(-120.0, -109.0)]
         super(ACISFPCheck, self).__init__("fptemp", "acisfp", valid_limits,
                                           hist_limit,
                                           other_telem=['1dahtbon'],

--- a/acisfp_check/acisfp_check.py
+++ b/acisfp_check/acisfp_check.py
@@ -444,7 +444,7 @@ class ACISFPCheck(ACISThermalCheck):
         # ------------------------------------------------------------
         # Science Orbit ECS -119.5 violations; -119.5 violation check
         # ------------------------------------------------------------
-        mylog.info('\n\nFP SENSITIVE -119.5 SCIENCE ONLY violations')
+        mylog.info('\n\nFP SENSITIVE -119.5 SCIENCE ORBIT ECS violations')
 
         viols["ecs"] = self.search_obsids_for_viols("Science Orbit ECS",
             self.fp_sens_limit, sci_ecs_obs, temp, times, load_start)
@@ -612,7 +612,7 @@ def draw_obsids(extract_and_filter,
 
         if obsid > 50000:
             # ECS observations during the science orbit are colored blue
-            color = 'royalblue'
+            color = 'blue'
         else:
             # Color all ACIS-S observations green; all ACIS-I
             # observations red

--- a/acisfp_check/templates/index_template.rst
+++ b/acisfp_check/templates/index_template.rst
@@ -58,21 +58,6 @@ Date start             Date stop              Max temperature     Obsids
 No ACIS-S -111 deg C FP_TEMP Violations
 {% endif %}
 
-
-{% if viols.fp_sens.fptemp %}
-FP TEMP Sensitive, -118.7 deg. C Preference Not Met:
--------------------------------------------------------------------
-=====================  =====================  ==================  ==================
-Date start             Date stop              Max temperature     OBSID
-=====================  =====================  ==================  ==================
-{% for viol in viols.fp_sens.fptemp %}
-{{viol.datestart}}  {{viol.datestop}}  {{"%.2f"|format(viol.maxtemp)}}             {{viol.obsid}}
-{% endfor %}
-=====================  =====================  ==================  ==================
-{% else %}
-No Focal Plane Sensitive Observation -118.7 deg C FP_TEMP Preferences Unmet
-{% endif %}
-
 .. image:: {{plots.acisfp_3.filename}}
 .. image:: {{plots.pow_sim.filename}}
 .. image:: {{plots.roll_taco.filename}}

--- a/acisfp_check/templates/index_template.rst
+++ b/acisfp_check/templates/index_template.rst
@@ -135,9 +135,6 @@ Earth Solid Angle
 {{ plot.msid }}
 -----------------------
 
-
-Red = telemetry, blue = model
-
 .. image:: {{plot.lines}}
 
 Data for FPTEMP residual plots limited between -120.0 and -112.0 deg. C

--- a/acisfp_check/templates/index_template.rst
+++ b/acisfp_check/templates/index_template.rst
@@ -58,6 +58,20 @@ Date start             Date stop              Max temperature     Obsids
 No ACIS-S -111 deg C FP_TEMP Violations
 {% endif %}
 
+{% if viols.ecs.fptemp %}
+Science Orbit ECS -119.5 deg C Violations
+-----------------------------------------
+=====================  =====================  ==================  ==================
+Date start             Date stop              Max temperature     OBSID
+=====================  =====================  ==================  ==================
+{% for viol in viols.ecs.fptemp %}
+{{viol.datestart}}  {{viol.datestop}}  {{"%.2f"|format(viol.maxtemp)}}             {{viol.obsid}}
+{% endfor %}
+=====================  =====================  ==================  ==================
+{% else %}
+No Science Orbit ECS -119.5 deg C FP_TEMP Violations
+{% endif %}
+
 .. image:: {{plots.acisfp_3.filename}}
 .. image:: {{plots.pow_sim.filename}}
 .. image:: {{plots.roll_taco.filename}}


### PR DESCRIPTION
## Description

This PR implements code changes relevant to two recent operational changes to the monitoring of the ACIS FP temperature, as well as a few other things:

* Some ACIS-S observations will be allowed to go to -109 C. This PR adjusts the top limit of the plots such that the -109 C limit is comfortably included, and adds a line at -109 C. What this PR does _not_ do is implement the code necessary to track the specific observations which are allowed to go to -109 C. Since the details of how these observations will be flagged are still under discussion, this will have to wait for a separate PR.
* Cold ECS measurements are now being scheduled in the science orbit. This PR contains the code necessary to show these observations on the prediction plot and track violations of the -119.5 C limit during these observations. 
* The notion of a "focal plane sensitive preference limit" at -118.7 C is also removed in this PR, since these preferences are almost never met anymore. 
* The acronym "CTI" is replaced with "ECS" nearly everywhere, since "ECS" is a more accurate name of the type of observation which is being carried out. 
* An incorrect (and obsolete) extra legend for the FP temp validation plot has been removed. 

This PR depends on the companion PR https://github.com/acisops/acis_thermal_check/pull/31.

Example page showing what all of this looks like can be seen here:

https://cxc.cfa.harvard.edu/acis/tmp/fp_jul0620/

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing
